### PR TITLE
Add base_url list support for IST landscapes

### DIFF
--- a/js/obs_store/obs_store.js
+++ b/js/obs_store/obs_store.js
@@ -32,6 +32,7 @@ export const create_obs_store = () => {
         new_cell_bar_data: Observable([]),
         new_gene_bar_data: Observable([]),
         selected_genes: Observable([]),
+        base_url: Observable(''),
         viz_image_layers: Observable(true),
         deck_check: Observable({
             background_layer: true,

--- a/js/ui/ui_containers.js
+++ b/js/ui/ui_containers.js
@@ -81,6 +81,49 @@ export const make_ctrl_container = () => {
   return ctrl_container;
 };
 
+
+export const make_baseurl_selector = (
+  base_url,
+  base_urls,
+  viz_state
+) => {
+  const container = flex_container('baseurl_selector_container', 'row');
+
+  if (base_urls.length <= 1) {
+    const label = document.createElement('div');
+    label.textContent = base_url;
+    label.style.marginLeft = '2px';
+    label.style.marginRight = '4px';
+    container.appendChild(label);
+    return container;
+  }
+
+  const select = document.createElement('select');
+  select.style.height = '20px';
+  select.style.marginLeft = '2px';
+  select.style.marginRight = '4px';
+
+  base_urls.forEach((url) => {
+    const opt = document.createElement('option');
+    opt.value = url;
+    opt.textContent = url;
+    select.appendChild(opt);
+  });
+
+  select.value = base_url;
+
+  select.addEventListener('change', (event) => {
+    viz_state.model.set('base_url', event.target.value);
+    viz_state.model.save_changes();
+    if (viz_state.obs_store && viz_state.obs_store.base_url) {
+      viz_state.obs_store.base_url.set(event.target.value);
+    }
+  });
+
+  container.appendChild(select);
+  return container;
+};
+
 export const flex_container = (class_name, flex_direction, height = null) => {
   const container = document.createElement('div');
   container.className = class_name;
@@ -237,12 +280,17 @@ export const make_matrix_ui_container = (deck_mat, layers_mat, viz_state) => {
   slider_container.style.marginLeft = '10px';
 
   ui_container.appendChild(ctrl_container);
+
   ui_container.appendChild(slider_container);
 
   return ui_container;
 };
 
-export const make_sst_ui_container = (deck_sst, layers_sst, viz_state) => {
+export const make_sst_ui_container = (
+  deck_sst,
+  layers_sst,
+  viz_state
+) => {
   const ui_container = make_ui_container();
   const ctrl_container = make_ctrl_container();
   const image_container = flex_container('image_container', 'row');
@@ -292,13 +340,19 @@ export const make_sst_ui_container = (deck_sst, layers_sst, viz_state) => {
 };
 
 export const make_ist_ui_container = (
-  dataset_name,
+  base_url,
+  base_urls,
   deck_ist,
   layers_obj,
   viz_state
 ) => {
   const ui_container = make_ui_container();
   const ctrl_container = make_ctrl_container();
+  const baseurl_selector = make_baseurl_selector(
+    base_url,
+    base_urls,
+    viz_state
+  );
 
   viz_state.containers.image = flex_container('image_container', 'column');
 
@@ -768,6 +822,7 @@ export const make_ist_ui_container = (
   )
 
   ui_container.appendChild(ctrl_container);
+  ctrl_container.appendChild(baseurl_selector);
 
   ctrl_container.appendChild(viz_state.containers.image);
   ctrl_container.appendChild(cell_container);

--- a/js/viz/landscape_h_e.js
+++ b/js/viz/landscape_h_e.js
@@ -17,7 +17,6 @@ export const landscape_h_e = async (
   ini_y,
   ini_z,
   ini_zoom,
-  _dataset_name = '',
   width = 0,
   height = 800,
   creds = {}

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -76,7 +76,7 @@ export const landscape_ist = async (
   ini_z,
   ini_zoom,
   base_url,
-  dataset_name = '',
+  base_urls = [],
   trx_radius = 0.25,
   width = 0,
   height = 800,
@@ -96,6 +96,7 @@ export const landscape_ist = async (
   const viz_state = {};
 
   viz_state.obs_store = create_obs_store();
+  viz_state.obs_store.base_url.set(base_url);
 
   const update_viz_image_layers = () => {
     const hasCats = viz_state.obs_store.selected_cats.get().length > 0;
@@ -422,7 +423,8 @@ export const landscape_ist = async (
   }
 
   const ui_container = make_ist_ui_container(
-    dataset_name,
+    base_url,
+    base_urls,
     deck_ist,
     layers_obj,
     viz_state
@@ -431,6 +433,40 @@ export const landscape_ist = async (
   // UI and Viz Container
   el.appendChild(ui_container);
   el.appendChild(root);
+
+  const reload_dataset = async (new_url) => {
+    deck_ist.finalize();
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
+    await landscape_ist(
+      el,
+      viz_state.model,
+      token,
+      ini_x,
+      ini_y,
+      ini_z,
+      ini_zoom,
+      new_url,
+      base_urls,
+      trx_radius,
+      width,
+      height,
+      meta_cell,
+      meta_cluster,
+      umap,
+      landscape_state,
+      segmentation,
+      creds,
+      view_change_custom_callback
+    );
+  };
+
+  viz_state.obs_store.base_url.subscribe((new_url) => {
+    if (new_url !== viz_state.global_base_url) {
+      reload_dataset(new_url);
+    }
+  }, { immediate: false });
 
   const landscape = {
     update_matrix_gene: async (inst_gene) => {

--- a/js/viz/landscape_sst.js
+++ b/js/viz/landscape_sst.js
@@ -34,7 +34,6 @@ export const landscape_sst = async (
   ini_z,
   ini_zoom,
   square_tile_size = 1.4,
-  _dataset_name = '',
   width = 0,
   height = 800
 ) => {
@@ -157,7 +156,11 @@ export const landscape_sst = async (
 
   set_tile_layer_onclick(deck_sst, layers_sst, viz_state);
 
-  const ui_container = make_sst_ui_container(deck_sst, layers_sst, viz_state);
+  const ui_container = make_sst_ui_container(
+    deck_sst,
+    layers_sst,
+    viz_state
+  );
 
   // UI and Viz Container
   el.appendChild(ui_container);

--- a/js/widget.js
+++ b/js/widget.js
@@ -18,7 +18,7 @@ const render_landscape_ist = async ({ model, el }) => {
   const ini_z = model.get('ini_z');
   const ini_zoom = model.get('ini_zoom');
   const base_url = model.get('base_url');
-  const dataset_name = model.get('dataset_name');
+  const base_urls = model.get('base_urls');
   const width = model.get('width');
   const height = model.get('height');
   const meta_cell = model.get('meta_cell');
@@ -36,7 +36,7 @@ const render_landscape_ist = async ({ model, el }) => {
     ini_z,
     ini_zoom,
     base_url,
-    dataset_name,
+    base_urls,
     0.25,
     width,
     height,
@@ -56,7 +56,6 @@ const render_landscape_sst = async ({ model, el }) => {
   const ini_z = model.get('ini_z');
   const ini_zoom = model.get('ini_zoom');
   const base_url = model.get('base_url');
-  const dataset_name = model.get('dataset_name');
   const square_tile_size = model.get('square_tile_size');
   const width = model.get('width');
   const height = model.get('height');
@@ -71,7 +70,6 @@ const render_landscape_sst = async ({ model, el }) => {
     ini_z,
     ini_zoom,
     square_tile_size,
-    dataset_name,
     width,
     height
   );
@@ -84,7 +82,6 @@ const render_landscape_h_e = async ({ model, el }) => {
   const ini_z = model.get('ini_z');
   const ini_zoom = model.get('ini_zoom');
   const base_url = model.get('base_url');
-  const dataset_name = model.get('dataset_name');
   const width = model.get('width');
   const height = model.get('height');
   const creds = model.get('creds');
@@ -98,7 +95,6 @@ const render_landscape_h_e = async ({ model, el }) => {
     ini_y,
     ini_z,
     ini_zoom,
-    dataset_name,
     width,
     height,
     creds

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -19,7 +19,7 @@ class Landscape(anywidget.AnyWidget):
         ini_zoom (float): The initial zoom level of the view.
         token (str): The token traitlet.
         base_url (str): The base URL for the widget.
-        dataset_name (str, optional): The name of the dataset to visualize. This will show up in the user interface bar.
+        base_urls (list[str], optional): A list of base URLs for multi-tenant visualizations.
 
     Attributes:
         component (str): The name of the component.
@@ -30,7 +30,7 @@ class Landscape(anywidget.AnyWidget):
         ini_y (float): The initial y-coordinate of the view.
         ini_z (float): The initial z-coordinate of the view.
         ini_zoom (float): The initial zoom level of the view.
-        dataset_name (str): The name of the dataset to visualize.
+        base_urls (list[str]): Available base URLs when multiple datasets are provided.
         update_trigger (dict): The dictionary to trigger updates.
         cell_clusters (dict): The dictionary containing cell cluster information.
 
@@ -44,6 +44,7 @@ class Landscape(anywidget.AnyWidget):
 
     technology = traitlets.Unicode("sst").tag(sync=True)
     base_url = traitlets.Unicode("").tag(sync=True)
+    base_urls = traitlets.List(traitlets.Unicode(), default_value=[]).tag(sync=True)
     token = traitlets.Unicode("").tag(sync=True)
     creds = traitlets.Dict({}).tag(sync=True)
     ini_x = traitlets.Float().tag(sync=True)
@@ -51,7 +52,6 @@ class Landscape(anywidget.AnyWidget):
     ini_z = traitlets.Float().tag(sync=True)
     ini_zoom = traitlets.Float(0).tag(sync=True)
     square_tile_size = traitlets.Float(1.4).tag(sync=True)
-    dataset_name = traitlets.Unicode("").tag(sync=True)
     region = traitlets.Dict({}).tag(sync=True)
     nbhd = traitlets.Dict({}).tag(sync=True)
 


### PR DESCRIPTION
## Summary
- add `base_url` observable to the store
- wire dropdown changes into the observable
- reload IST landscape whenever the base URL changes
- drop dataset name fields in favor of base_url lists

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_685ff5ab275c832a9dca3e85d79eac69