### PR TITLE
starting to work on setProps obs_store

### DIFF
--- a/js/obs_store/obs_store.js
+++ b/js/obs_store/obs_store.js
@@ -29,6 +29,7 @@ export const create_obs_store = () => {
     new_gene_bar_data: Observable([]),
     selected_genes: Observable([]),
     viz_image_layers: Observable(true),
+    // to do utilize for setProps
     deck_check: Observable({
       background_layer: true,
       image_layers: true,


### PR DESCRIPTION
This pull request will use the `deck_check` observable to check that all deck layers are ready before setting a new observable (probably `deck_ready`) that will be used to setProps in a subscriber.