### PR TITLE
Update custom shaders for deck.gl v9

### DIFF
--- a/js/deck-gl/layers/CustomBitmapLayer.js
+++ b/js/deck-gl/layers/CustomBitmapLayer.js
@@ -6,12 +6,9 @@ export class CustomBitmapLayer extends BitmapLayer {
     // Directly injecting shader code
     shaders.inject = {
       'fs:#decl': `uniform vec3 uColor; uniform float uOpacityScale;`,
-      'fs:DECKGL_FILTER_COLOR': `
-        // Convert color to grayscale and apply opacity scale
+      'fs:DECKGL_FILTER_COLOR(inout vec4 color, Geometry geometry)': `
         float grayscale = ((color.r + color.g + color.b) / 3.0) * uOpacityScale;
-        // Clamp grayscale to valid range
         grayscale = clamp(grayscale, 0.0, 1.0);
-        // Apply custom color and scaled opacity
         color = vec4(uColor, grayscale);
       `,
     };

--- a/js/deck-gl/layers/edit_layer.js
+++ b/js/deck-gl/layers/edit_layer.js
@@ -1,231 +1,209 @@
-// to do: re-enable edit_layer
+/* eslint-disable import/no-cycle */
+import {
+  EditableGeoJsonLayer,
+  ModifyMode,
+  ViewMode,
+} from '@deck.gl-community/editable-layers';
+import * as d3 from 'd3';
 
-// // /* eslint-disable import/no-cycle */
+import { handleValidationWarning } from '../../temp_utils/errorHandler';
+import { get_layers_list } from '../utils/layers_ist';
 
-// import {
-//   EditableGeoJsonLayer,
-//   ModifyMode,
-//   ViewMode,
-// } from '@deck.gl-community/editable-layers';
-// import * as d3 from 'd3';
+import { update_cell_pickable_state } from './cell_layer';
+import { update_path_pickable_state } from './path_layer';
+import { update_trx_pickable_state } from './trx_layer';
 
-// import { handleValidationWarning } from '../../temp_utils/errorHandler';
-// import { get_layers_list } from '../utils/layers_ist';
+export function update_edit_layer_mode(layers_obj, mode) {
+  layers_obj.edit_layer = layers_obj.edit_layer.clone({
+    mode,
+  });
+}
 
-// import { update_cell_pickable_state } from './cell_layer';
-// import { update_path_pickable_state } from './path_layer';
-// import { update_trx_pickable_state } from './trx_layer';
+// Function to calculate areas from a FeatureCollection
+const calc_region_areas = (featureCollection) => {
+  featureCollection.features.forEach((feature, index) => {
+    if (feature.geometry.type === 'Polygon') {
+      const coordinates = feature.geometry.coordinates[0];
+      const area = Math.abs(d3.polygonArea(coordinates));
+      feature.properties = {
+        ...feature.properties,
+        area,
+        name: feature.properties.name || `Feature ${index + 1}`,
+        color:
+          feature.properties.color || [
+            Math.random() * 255,
+            Math.random() * 255,
+            Math.random() * 255,
+          ],
+      };
+    } else {
+      handleValidationWarning(`Feature ${index} is not a Polygon.`, {
+        logLevel: 'warn',
+        shouldLog: true,
+        data: { featureIndex: index, featureType: feature.geometry?.type },
+      });
+    }
+  });
 
-// // Forward declaration for function used before definition
-// function update_edit_layer_mode(layers_obj, mode) {
-//   layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//     mode,
-//   });
-// }
+  return featureCollection;
+};
 
-// // Function to calculate areas from a FeatureCollection
-// const calc_region_areas = (featureCollection) => {
-//   featureCollection.features.forEach((feature, index) => {
-//     if (feature.geometry.type === 'Polygon') {
-//       // Extract the outer ring of the polygon
-//       const coordinates = feature.geometry.coordinates[0];
+export const sync_region_to_model = (viz_state) => {
+  if (Object.keys(viz_state.model).length > 0) {
+    viz_state.model.set('region', {});
+    viz_state.model.set('region', viz_state.edit.feature_collection);
+    viz_state.model.save_changes();
+  }
+};
 
-//       // Calculate the area
-//       const area = Math.abs(d3.polygonArea(coordinates));
+export const calc_and_update_rgn_bar_graph = async (viz_state) => {
+  viz_state.edit.feature_collection = calc_region_areas(
+    viz_state.edit.feature_collection
+  );
 
-//       // Update the properties
-//       feature.properties = {
-//         ...feature.properties,
-//         area, // Store the calculated area
-//         name: feature.properties.name || `Feature ${index + 1}`, // Default name if not set
-//         color: feature.properties.color || [
-//           Math.random() * 255,
-//           Math.random() * 255,
-//           Math.random() * 255,
-//         ], // Default color if not set
-//       };
-//     } else {
-//       handleValidationWarning(`Feature ${index} is not a Polygon.`, {
-//         logLevel: 'warn',
-//         shouldLog: true,
-//         data: { featureIndex: index, featureType: feature.geometry?.type },
-//       });
-//     }
-//   });
+  viz_state.edit.rgn_areas = viz_state.edit.feature_collection.features
+    .map((feature, index) => ({
+      name: (index + 1).toString(),
+      value: feature.properties.area,
+    }))
+    .sort((a, b) => b.value - a.value);
 
-//   return featureCollection; // Return updated FeatureCollection
-// };
+  viz_state.edit.color_dict_rgn = viz_state.edit.feature_collection.features.reduce(
+    (acc, feature, index) => {
+      acc[(index + 1).toString()] = feature.properties.color;
+      return acc;
+    },
+    {}
+  );
+};
 
-// export const sync_region_to_model = (viz_state) => {
-//   if (Object.keys(viz_state.model).length > 0) {
-//     viz_state.model.set('region', {});
-//     viz_state.model.set('region', viz_state.edit.feature_collection);
-//     viz_state.model.save_changes();
-//   }
-// };
+const edit_layer_on_edit = async (deck_ist, layers_obj, viz_state, edit_info) => {
+  const { updatedData, editType } = edit_info;
 
-// export const calc_and_update_rgn_bar_graph = async (
-//   viz_state
-// ) => {
-//   // Calculate areas
-//   viz_state.edit.feature_collection = calc_region_areas(
-//     viz_state.edit.feature_collection
-//   );
+  viz_state.edit.feature_collection = updatedData;
 
-//   viz_state.edit.rgn_areas = viz_state.edit.feature_collection.features
-//     .map((feature, index) => ({
-//       name: (index + 1).toString(), // Assign numeric names starting from 1
-//       value: feature.properties.area, // Use the "area" property for the bar height
-//     }))
-//     .sort((a, b) => b.value - a.value);
+  layers_obj.edit_layer = layers_obj.edit_layer.clone({
+    data: viz_state.edit.feature_collection,
+  });
 
-//   viz_state.edit.color_dict_rgn =
-//     viz_state.edit.feature_collection.features.reduce((acc, feature, index) => {
-//       acc[(index + 1).toString()] = feature.properties.color; // Use the "color" property
-//       return acc;
-//     }, {});
+  if (editType === 'addFeature') {
+    update_edit_layer_mode(layers_obj, ViewMode);
 
-// };
+    d3.select(viz_state.edit.buttons.sktch)
+      .style('color', 'gray')
+      .classed('active', false);
 
-// const edit_layer_on_edit = async (
-//   deck_ist,
-//   layers_obj,
-//   viz_state,
-//   edit_info
-// ) => {
-//   // const { updatedData, editType, featureIndexes, editContext } = edit_info;
-//   const { updatedData, editType } = edit_info;
+    viz_state.edit.mode = 'view';
 
-//   viz_state.edit.feature_collection = updatedData;
+    update_cell_pickable_state(layers_obj, true);
+    update_path_pickable_state(layers_obj, true);
+    update_trx_pickable_state(layers_obj, true);
 
-//   layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//     data: viz_state.edit.feature_collection,
-//   });
+    await calc_and_update_rgn_bar_graph(viz_state);
 
-//   if (editType === 'addFeature') {
-//     update_edit_layer_mode(layers_obj, ViewMode);
+    sync_region_to_model(viz_state);
+  }
 
-//     d3.select(viz_state.edit.buttons.sktch)
-//       .style('color', 'gray')
-//       .classed('active', false);
+  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
+  deck_ist.setProps({ layers: layers_list });
+  await calc_and_update_rgn_bar_graph(viz_state);
+  sync_region_to_model(viz_state);
+};
 
-//     viz_state.edit.mode = 'view';
+const edit_layer_on_click = async (event, deck_ist, layers_obj, viz_state) => {
+  if (event.featureType === 'polygons' && viz_state.edit.mode === 'view') {
+    layers_obj.edit_layer = layers_obj.edit_layer.clone({
+      id: 'edit-layer-modify',
+      mode: ModifyMode,
+      selectedFeatureIndexes: [event.index],
+      modeConfig: {
+        dragToAddNew: true,
+        enableSnapping: false,
+      },
+    });
 
-//     update_cell_pickable_state(layers_obj, true);
-//     update_path_pickable_state(layers_obj, true);
-//     update_trx_pickable_state(layers_obj, true);
+    const layers_list = await get_layers_list(layers_obj, viz_state.close_up);
+    deck_ist.setProps({ layers: layers_list });
 
-//     await calc_and_update_rgn_bar_graph(viz_state);
+    viz_state.edit.mode = 'modify';
 
-//     sync_region_to_model(viz_state);
-//   }
+    viz_state.edit.modify_index = event.index;
 
-//   const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-//   deck_ist.setProps({ layers: layers_list });
-//   await calc_and_update_rgn_bar_graph(viz_state);
-//   sync_region_to_model(viz_state);
-// };
+    d3.select(viz_state.edit.buttons.del)
+      .classed('active', true)
+      .style('display', 'inline-flex');
 
-// const edit_layer_on_click = async (event, deck_ist, layers_obj, viz_state) => {
-//   if (event.featureType === 'polygons' && viz_state.edit.mode === 'view') {
-//     // switch to modify mode
-//     layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//       id: 'edit-layer-modify',
-//       mode: ModifyMode,
-//       selectedFeatureIndexes: [event.index],
-//       modeConfig: {
-//         dragToAddNew: true, // Enable dragging along edges to create new nodes
-//         enableSnapping: false, // Disable snapping to nearby nodes
-//       },
-//     });
+    d3.select(viz_state.edit.buttons.rgn).style('display', 'none');
 
-//     const layers_list = await get_layers_list(layers_obj, viz_state.close_up);
-//     deck_ist.setProps({ layers: layers_list });
+    d3.select(viz_state.edit.buttons.sktch).style('display', 'none');
+  } else if (
+    event.featureType === 'polygons' &&
+    viz_state.edit.mode === 'modify'
+  ) {
+    layers_obj.edit_layer = layers_obj.edit_layer.clone({
+      id: 'edit-layer-view',
+      mode: ViewMode,
+      selectedFeatureIndexes: [],
+    });
 
-//     viz_state.edit.mode = 'modify';
+    const layers_list = await get_layers_list(layers_obj, viz_state.close_up);
+    deck_ist.setProps({ layers: layers_list });
 
-//     viz_state.edit.modify_index = event.index;
+    viz_state.edit.mode = 'view';
 
-//     // make the DEL button red and active
-//     d3.select(viz_state.edit.buttons.del)
-//       .classed('active', true)
-//       .style('display', 'inline-flex');
+    viz_state.edit.modify_index = null;
 
-//     // hide the RGN and SKTCH buttons
-//     d3.select(viz_state.edit.buttons.rgn).style('display', 'none');
+    d3.select(viz_state.edit.buttons.del)
+      .classed('active', false)
+      .style('display', 'none');
 
-//     d3.select(viz_state.edit.buttons.sktch).style('display', 'none');
-//   } else if (
-//     event.featureType === 'polygons' &&
-//     viz_state.edit.mode === 'modify'
-//   ) {
-//     // switch to view mode
-//     layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//       id: 'edit-layer-view',
-//       mode: ViewMode,
-//       selectedFeatureIndexes: [],
-//     });
+    d3.select(viz_state.edit.buttons.rgn).style('display', 'inline-flex');
 
-//     const layers_list = await get_layers_list(layers_obj, viz_state.close_up);
-//     deck_ist.setProps({ layers: layers_list });
+    d3.select(viz_state.edit.buttons.sktch).style('display', 'inline-flex');
+  }
+};
 
-//     viz_state.edit.mode = 'view';
+export const ini_edit_layer = (viz_state) => {
+  const edit_layer = new EditableGeoJsonLayer({
+    id: 'edit-layer',
+    data: viz_state.edit.feature_collection,
+    selectedFeatureIndexes: [],
+    mode: ViewMode,
+    filled: true,
+    pointRadiusMinPixels: 2,
+    pointRadiusScale: 2000,
+    extruded: true,
+    getElevation: 1000,
+    getFillColor: (d) => d.properties.color,
+    pickable: true,
+    autoHighlight: true,
+    modeConfig: {
+      preventOverlappingLines: true,
+    },
+    visible: false,
+  });
 
-//     viz_state.edit.modify_index = null;
+  return edit_layer;
+};
 
-//     // hide the DEL button
-//     d3.select(viz_state.edit.buttons.del)
-//       .classed('active', false)
-//       .style('display', 'none');
+export const set_edit_layer_on_edit = (deck_ist, layers_obj, viz_state) => {
+  layers_obj.edit_layer = layers_obj.edit_layer.clone({
+    onEdit: (edit_info) =>
+      edit_layer_on_edit(deck_ist, layers_obj, viz_state, edit_info),
+  });
+};
 
-//     // hide the RGN and SKTCH buttons
-//     d3.select(viz_state.edit.buttons.rgn).style('display', 'inline-flex');
+export const set_edit_layer_on_click = (deck_ist, layers_obj, viz_state) => {
+  layers_obj.edit_layer = layers_obj.edit_layer.clone({
+    onClick: (event) =>
+      edit_layer_on_click(event, deck_ist, layers_obj, viz_state),
+  });
+};
 
-//     d3.select(viz_state.edit.buttons.sktch).style('display', 'inline-flex');
-//   }
-// };
+export { update_edit_layer_mode };
 
-// export const ini_edit_layer = (viz_state) => {
-//   const edit_layer = new EditableGeoJsonLayer({
-//     id: 'edit-layer',
-//     data: viz_state.edit.feature_collection,
-//     selectedFeatureIndexes: [],
-//     mode: ViewMode,
-//     filled: true,
-//     pointRadiusMinPixels: 2,
-//     pointRadiusScale: 2000,
-//     extruded: true,
-//     getElevation: 1000,
-//     getFillColor: (d) => d.properties.color,
-//     pickable: true,
-//     autoHighlight: true,
-//     modeConfig: {
-//       preventOverlappingLines: true,
-//     },
-//     visible: false,
-//   });
-
-//   return edit_layer;
-// };
-
-// export const set_edit_layer_on_edit = (deck_ist, layers_obj, viz_state) => {
-//   layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//     onEdit: (edit_info) =>
-//       edit_layer_on_edit(deck_ist, layers_obj, viz_state, edit_info),
-//   });
-// };
-
-// export const set_edit_layer_on_click = (deck_ist, layers_obj, viz_state) => {
-//   layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//     onClick: (event) =>
-//       edit_layer_on_click(event, deck_ist, layers_obj, viz_state),
-//   });
-// };
-
-// export { update_edit_layer_mode };
-
-// export const update_edit_visitility = (layers_obj, visible) => {
-//   layers_obj.edit_layer = layers_obj.edit_layer.clone({
-//     visible,
-//   });
-// };
+export const update_edit_visitility = (layers_obj, visible) => {
+  layers_obj.edit_layer = layers_obj.edit_layer.clone({
+    visible,
+  });
+};

--- a/js/deck-gl/matrix/custom_matrix_layer.js
+++ b/js/deck-gl/matrix/custom_matrix_layer.js
@@ -12,8 +12,10 @@ export class CustomMatrixLayer extends ScatterplotLayer {
   }
 
   // Add custom uniforms
-  draw({ uniforms }) {
+  draw(opts) {
+    const { uniforms } = opts;
     super.draw({
+      ...opts,
       uniforms: {
         ...uniforms,
         tile_height: this.props.tile_height,


### PR DESCRIPTION
## Summary
- update shader injection syntax for CustomBitmapLayer
- adjust CustomMatrixLayer draw method for deck.gl v9 opts
- re-enable EditableGeoJsonLayer integration

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_686934ab2904832aa1b6154f97cdfcd8