### PR TITLE
Fix Parquet matrix export and parsing

### DIFF
--- a/js/read_parquet/network_from_parquet.js
+++ b/js/read_parquet/network_from_parquet.js
@@ -1,0 +1,57 @@
+import { arrayBufferToArrowTable } from './arrayBufferToArrowTable';
+
+function tableToObjects(table) {
+  const cols = {};
+  table.schema.fields.forEach((f) => {
+    cols[f.name] = table.getChild(f.name).toArray();
+  });
+  const rows = [];
+  for (let i = 0; i < table.numRows; i++) {
+    const obj = {};
+    table.schema.fields.forEach((f) => {
+      obj[f.name] = cols[f.name][i];
+    });
+    rows.push(obj);
+  }
+  return rows;
+}
+
+function tableToMatrix(table) {
+  let colNames = table.schema.fields.map((f) => f.name);
+  if (colNames[0] === 'row' || colNames[0] === 'index') {
+    colNames = colNames.slice(1);
+  }
+  const cols = colNames.map((n) => table.getChild(n).toArray());
+  const mat = [];
+  for (let r = 0; r < table.numRows; r++) {
+    const row = cols.map((c) => c[r]);
+    mat.push(Array.from(row));
+  }
+  return mat;
+}
+
+export const networkFromParquet = async (
+  meta,
+  matBytes,
+  rowNodesBytes,
+  colNodesBytes,
+  rowLinkBytes,
+  colLinkBytes
+) => {
+  const matTable = await arrayBufferToArrowTable(matBytes.buffer);
+  const rowNodesTable = await arrayBufferToArrowTable(rowNodesBytes.buffer);
+  const colNodesTable = await arrayBufferToArrowTable(colNodesBytes.buffer);
+  const rowLinkTable = await arrayBufferToArrowTable(rowLinkBytes.buffer);
+  const colLinkTable = await arrayBufferToArrowTable(colLinkBytes.buffer);
+
+  const network = { ...meta };
+  network.mat = tableToMatrix(matTable);
+  network.row_nodes = tableToObjects(rowNodesTable);
+  network.col_nodes = tableToObjects(colNodesTable);
+  network.linkage = {
+    row: tableToMatrix(rowLinkTable),
+    col: tableToMatrix(colLinkTable),
+  };
+
+  return network;
+};

--- a/js/widget.js
+++ b/js/widget.js
@@ -7,6 +7,7 @@ import { landscape_h_e } from './viz/landscape_h_e';
 import { landscape_ist } from './viz/landscape_ist';
 import { landscape_sst } from './viz/landscape_sst';
 import { matrix_viz } from './viz/matrix_viz';
+import { networkFromParquet } from './read_parquet/network_from_parquet';
 
 // Remove export keywords from render functions
 const render_landscape_ist = async ({ model, el }) => {
@@ -117,9 +118,21 @@ const render_landscape = async ({ model, el }) => {
 };
 
 const render_matrix_new = async ({ model, el }) => {
-  const network = model.get('network');
+  let network = model.get('network');
   const width = model.get('width');
   const height = model.get('height');
+
+  const matBytes = model.get('mat_parquet');
+  if (matBytes && matBytes.byteLength > 0) {
+    network = await networkFromParquet(
+      model.get('network_meta'),
+      matBytes,
+      model.get('row_nodes_parquet'),
+      model.get('col_nodes_parquet'),
+      model.get('row_linkage_parquet'),
+      model.get('col_linkage_parquet')
+    );
+  }
 
   matrix_viz(model, el, network, width, height);
 };

--- a/src/celldega/clust/matrix.py
+++ b/src/celldega/clust/matrix.py
@@ -56,10 +56,11 @@ def quick_hash_data(data: pd.DataFrame | AnnData, max_rows=100, max_cols=100) ->
             import scipy.sparse
             x = data.X
             if scipy.sparse.issparse(x):
-                x = x.toarray()
-            x = np.asarray(x, dtype=np.float32)
-            row_means = x.mean(axis=1)[:max_rows]
-            col_means = x.mean(axis=0)[:max_cols]
+                x = x[:max_rows, :max_cols].toarray()
+            else:
+                x = np.asarray(x[:max_rows, :max_cols], dtype=np.float32)
+            row_means = x.mean(axis=1)
+            col_means = x.mean(axis=0)
         else:
             return f"cgm_{id(data)}"
 

--- a/src/celldega/clust/matrix.py
+++ b/src/celldega/clust/matrix.py
@@ -592,6 +592,56 @@ class Matrix:
         """Export visualization for widget."""
         return self.export_viz_json_string()
 
+    def export_viz_parquet(self) -> dict[str, bytes]:
+        """Export visualization using Parquet encoded tables."""
+        if not self._clustered:
+            warnings.warn(
+                "Matrix not clustered. Call clust() first.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        import io
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        def _to_bytes(df: pd.DataFrame) -> bytes:
+            buf = io.BytesIO()
+            pq.write_table(
+                pa.Table.from_pandas(df, preserve_index=False),
+                buf,
+                compression="zstd",
+            )
+            return buf.getvalue()
+
+        viz = self.viz
+
+        mat_df = pd.DataFrame(
+            self.dat["mat"],
+            index=self.dat["nodes"][Axis.ROW.value],
+            columns=self.dat["nodes"][Axis.COL.value],
+        )
+
+        row_nodes_df = pd.DataFrame(viz.get("row_nodes", []))
+        col_nodes_df = pd.DataFrame(viz.get("col_nodes", []))
+        row_link_df = pd.DataFrame(viz.get("linkage", {}).get(Axis.ROW.value, []))
+        col_link_df = pd.DataFrame(viz.get("linkage", {}).get(Axis.COL.value, []))
+
+        meta_json = viz.copy()
+        meta_json.pop("mat", None)
+        meta_json.pop("row_nodes", None)
+        meta_json.pop("col_nodes", None)
+        meta_json["linkage"] = {}
+
+        return {
+            "mat": _to_bytes(mat_df),
+            "row_nodes": _to_bytes(row_nodes_df),
+            "col_nodes": _to_bytes(col_nodes_df),
+            "row_linkage": _to_bytes(row_link_df),
+            "col_linkage": _to_bytes(col_link_df),
+            "meta": meta_json,
+        }
+
     def add_category(self, axis: AxisInput, name: str, data: pd.Series) -> None:
         """
         Add category to metadata.

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -116,15 +116,36 @@ class Clustergram(anywidget.AnyWidget):
     value = traitlets.Int(0).tag(sync=True)
     component = traitlets.Unicode("Clustergram").tag(sync=True)
     network = traitlets.Dict({}).tag(sync=True)
+    network_meta = traitlets.Dict({}).tag(sync=True)
+    mat_parquet = traitlets.Bytes(b"").tag(sync=True)
+    row_nodes_parquet = traitlets.Bytes(b"").tag(sync=True)
+    col_nodes_parquet = traitlets.Bytes(b"").tag(sync=True)
+    row_linkage_parquet = traitlets.Bytes(b"").tag(sync=True)
+    col_linkage_parquet = traitlets.Bytes(b"").tag(sync=True)
     width = traitlets.Int(600).tag(sync=True)
     height = traitlets.Int(600).tag(sync=True)
     click_info = traitlets.Dict({}).tag(sync=True)
 
     def __init__(self, **kwargs):
 
-        # set name from network.name
+        # set name from network.name or parquet meta
+        name = None
         if "network" in kwargs:
             name = kwargs["network"].get("name", None)
+        if "parquet_data" in kwargs:
+            pq_data = kwargs.pop("parquet_data")
+            meta = pq_data.get("meta", {})
+            name = meta.get("name", name)
+            kwargs.setdefault("network_meta", meta)
+            kwargs.setdefault("mat_parquet", pq_data.get("mat", b""))
+            kwargs.setdefault("row_nodes_parquet", pq_data.get("row_nodes", b""))
+            kwargs.setdefault("col_nodes_parquet", pq_data.get("col_nodes", b""))
+            kwargs.setdefault(
+                "row_linkage_parquet", pq_data.get("row_linkage", b"")
+            )
+            kwargs.setdefault(
+                "col_linkage_parquet", pq_data.get("col_linkage", b"")
+            )
 
         # Close any previously registered widget with the same name
         old_widget = _clustergram_registry.get(name)

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -114,7 +114,7 @@ class Clustergram(anywidget.AnyWidget):
     _css = Path(__file__).parent / "../static" / "widget.css"
 
     value = traitlets.Int(0).tag(sync=True)
-    component = traitlets.Unicode("Matrix").tag(sync=True)
+    component = traitlets.Unicode("Clustergram").tag(sync=True)
     network = traitlets.Dict({}).tag(sync=True)
     width = traitlets.Int(600).tag(sync=True)
     height = traitlets.Int(600).tag(sync=True)


### PR DESCRIPTION
## Summary
- write Parquet tables without DataFrame indices
- skip index columns when parsing Parquet matrix on the frontend

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov)*
- `npm run build` *(fails: cannot find package 'esbuild')*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6867f3185c98832a87f37669d6a56033