### PR TITLE
Fix qc test and tidy exports

### DIFF
--- a/src/celldega/clust/matrix.py
+++ b/src/celldega/clust/matrix.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 from typing import Any
 import warnings
@@ -9,6 +10,8 @@ import weakref
 from anndata import AnnData
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from scipy.cluster.hierarchy import dendrogram, linkage
 from scipy.spatial.distance import pdist
 from sklearn.preprocessing import QuantileTransformer
@@ -46,6 +49,7 @@ from .utils import (
 _distance_cache = weakref.WeakKeyDictionary()
 _ranking_cache = weakref.WeakKeyDictionary()
 
+
 def quick_hash_data(data: pd.DataFrame | AnnData, max_rows=100, max_cols=100) -> str:
     try:
         if isinstance(data, pd.DataFrame):
@@ -54,6 +58,7 @@ def quick_hash_data(data: pd.DataFrame | AnnData, max_rows=100, max_cols=100) ->
             col_means = df.mean(axis=0).values[:max_cols]
         elif isinstance(data, AnnData):
             import scipy.sparse
+
             x = data.X
             if scipy.sparse.issparse(x):
                 x = x[:max_rows, :max_cols].toarray()
@@ -69,6 +74,7 @@ def quick_hash_data(data: pd.DataFrame | AnnData, max_rows=100, max_cols=100) ->
         return f"cgm_{hashlib.md5(sig_bytes).hexdigest()[:12]}"
     except Exception:
         return f"cgm_{id(data)}"
+
 
 class Matrix:
     """
@@ -601,10 +607,6 @@ class Matrix:
                 stacklevel=2,
             )
 
-        import io
-        import pyarrow as pa
-        import pyarrow.parquet as pq
-
         def _to_bytes(df: pd.DataFrame) -> bytes:
             buf = io.BytesIO()
             pq.write_table(
@@ -724,7 +726,9 @@ class Matrix:
         if self._clustered:
             self.make_viz()
 
-    def set_global_cat_colors(self, color_mapping: dict[str, str] | pd.DataFrame | None = None) -> None:
+    def set_global_cat_colors(
+        self, color_mapping: dict[str, str] | pd.DataFrame | None = None
+    ) -> None:
         """
         Set global category color mapping that applies across all categories.
 
@@ -764,7 +768,6 @@ class Matrix:
         self.viz["col_cats"] = self.col_cats
 
         self.viz["global_cat_colors"].update(color_mapping)
-
 
     def set_matrix_colors(self, pos: str = "red", neg: str = "blue") -> None:
         """

--- a/tests/unit/test_qc/test_qc_module.py
+++ b/tests/unit/test_qc/test_qc_module.py
@@ -17,4 +17,3 @@ def test_qc_module_exists():
     spec = util.find_spec("celldega.qc")
     if spec is None:
         pytest.skip("qc module not importable")
-    assert spec is not None

--- a/tests/unit/test_qc/test_qc_module.py
+++ b/tests/unit/test_qc/test_qc_module.py
@@ -1,16 +1,20 @@
 """
 Test celldega.qc module.
 """
-import pytest
-import sys
+
+from importlib import util
 from pathlib import Path
+import sys
+
+import pytest
+
 
 sys.path.insert(0, str(Path(__file__).parents[3] / "src"))
 
+
 def test_qc_module_exists():
     """Test that qc module exists."""
-    try:
-        from celldega import qc
-        assert True
-    except ImportError as e:
-        pytest.skip(f"qc module not importable: {e}")
+    spec = util.find_spec("celldega.qc")
+    if spec is None:
+        pytest.skip("qc module not importable")
+    assert spec is not None


### PR DESCRIPTION
## Summary
- sort imports in tests/unit/test_qc/test_qc_module.py
- use importlib to check for `celldega.qc`
- move IO and pyarrow imports in export_viz_parquet to the module level

## Testing
- `ruff check tests/unit/test_qc/test_qc_module.py src/celldega/clust/matrix.py`
- `ruff format tests/unit/test_qc/test_qc_module.py src/celldega/clust/matrix.py --check`
- `bash ./scripts/test.sh python` *(fails: Python environment './dega' not found)*
- `pytest tests/unit/test_qc/test_qc_module.py -q` *(fails: unrecognized arguments from pyproject)*

------
https://chatgpt.com/codex/tasks/task_b_686beb3dd800832a8e078bc2d5c9e109