### PR TITLE
Update docs for parquet_data usage

### DIFF
--- a/docs/overview/usage.md
+++ b/docs/overview/usage.md
@@ -1,3 +1,28 @@
 # Usage
 
-** coming soon **
+This section provides a minimal example of displaying a clustered matrix with Celldega.
+
+## Clustergram `parquet_data`
+
+The `Clustergram` widget accepts a `parquet_data` argument that contains the network encoded as Parquet tables. Using this approach avoids transferring large JSON structures to the browser. You can obtain this dictionary from a [`Matrix`](../python/clust/api.md#celldega.clust.matrix.Matrix.export_viz_parquet) instance using `Matrix.export_viz_parquet()`.
+
+```python
+import celldega as dega
+import pandas as pd
+
+# Load expression data
+df = pd.read_parquet("df_sig.parquet")
+
+# Create and cluster the matrix
+mat = dega.clust.Matrix(df, name="demo")
+mat.clust()
+
+# Export to Parquet-encoded bytes
+pq_data = mat.export_viz_parquet()
+
+# Initialize widget with parquet_data
+cgm = dega.viz.Clustergram(parquet_data=pq_data, width=500, height=500)
+cgm
+```
+
+`Clustergram` also accepts `network` or `matrix` arguments, but `parquet_data` is recommended for large datasets.

--- a/docs/python/viz/api.md
+++ b/docs/python/viz/api.md
@@ -2,5 +2,9 @@
 
 ## Widget Classes
 
+The `Clustergram` widget accepts a `parquet_data` argument for efficient
+initialization. Use [`Matrix.export_viz_parquet`](../clust/api.md#celldega.clust.matrix.Matrix.export_viz_parquet)
+to generate this data from a clustered matrix.
+
 ::: celldega.viz
 


### PR DESCRIPTION
## Summary
- document `Clustergram` `parquet_data` argument in usage guide
- mention `Matrix.export_viz_parquet()` in viz API docs

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_686bf38b1f44832aa53bedbc1af1ecb1