### PR TITLE
DEGA-290-custom-segmentation-landscape-files-fix

### DIFF
--- a/src/celldega/pre/__init__.py
+++ b/src/celldega/pre/__init__.py
@@ -842,13 +842,6 @@ def add_custom_segmentation(
         / f"meta_gene_{segmentation_parameters['segmentation_approach']}.parquet",
     )
 
-    save_cbg_gene_parquets(
-        base_path=path_landscape_files,
-        cbg=cbg_custom,
-        verbose=True,
-        segmentation_approach=segmentation_parameters["segmentation_approach"],
-    )
-
     make_meta_cell_image_coord(
         technology=segmentation_parameters["technology"],
         path_transformation_matrix=str(
@@ -862,6 +855,13 @@ def add_custom_segmentation(
             / f"cell_metadata_{segmentation_parameters['segmentation_approach']}.parquet"
         ),
         image_scale=image_scale,
+    )
+
+    save_cbg_gene_parquets(
+        base_path=path_landscape_files,
+        cbg=cbg_custom,
+        verbose=True,
+        segmentation_approach=segmentation_parameters["segmentation_approach"],
     )
 
     create_cluster_and_meta_cluster(

--- a/src/celldega/pre/boundary_tile.py
+++ b/src/celldega/pre/boundary_tile.py
@@ -259,13 +259,17 @@ def get_cell_polygons(
         )
         cells_orig = gpd.GeoDataFrame(grouped, geometry="geometry")[["geometry"]]
 
+        cells_orig.rename(columns={"geometry": "geometry_micron"}, inplace=True)
+
     # Transform geometries
     cells_orig["geometry"] = batch_transform_geometries(
-        cells_orig["geometry"], transformation_matrix, 1
+        cells_orig["geometry_micron"], transformation_matrix, 1
     )
     cells_orig["GEOMETRY"] = cells_orig["geometry"].apply(
         lambda geom: [[list(coord) for coord in geom.exterior.coords]]
     )
+
+    cells_orig.set_geometry("geometry", inplace=True)
 
     return cells_orig
 

--- a/src/celldega/qc/__init__.py
+++ b/src/celldega/qc/__init__.py
@@ -68,7 +68,7 @@ def _process_custom_technology(base_path):
     trx = pd.read_parquet(Path(base_path) / "transcripts.parquet")
     trx_meta = trx[trx[cell_index] != -1][[transcript_index, cell_index, gene]]
     cell_gdf = gpd.read_parquet(Path(base_path) / "cell_polygons.parquet")
-    cell_meta_gdf = gpd.read_parquet(Path(base_path) / "cell_metadata.parquet")
+    cell_meta_gdf = gpd.read_parquet(Path(base_path) / "cell_metadata_micron_space.parquet")
 
     return cell_index, gene, transcript_index, trx_meta, cell_gdf, cell_meta_gdf
 
@@ -92,12 +92,15 @@ def _process_xenium_technology(base_path, segmentation_parameters):
     trx = trx.rename(columns={"name": gene})
     trx_meta = trx[trx[cell_index] != "UNASSIGNED"][[transcript_index, cell_index, gene]]
 
+    transformation_matrix = pd.read_csv(Path(base_path) / "micron_to_image_transform.csv", header=None, sep=" ").values
     cell_gdf = get_cell_polygons(
         technology=segmentation_parameters["technology"],
         path_cell_boundaries=Path(base_path) / "cell_boundaries.parquet",
+        transformation_matrix = transformation_matrix
     )
 
-    cell_gdf = gpd.GeoDataFrame(geometry=cell_gdf["geometry"])
+    cell_gdf = gpd.GeoDataFrame(geometry=cell_gdf["geometry_micron"])
+
     cell_gdf["geometry"] = cell_gdf["geometry"].apply(get_largest_polygon)
     cell_gdf.reset_index(inplace=True)
     cell_gdf["area"] = cell_gdf["geometry"].area
@@ -461,6 +464,7 @@ def _create_barplot_visualization(
     - cell_a_name: Name of cell type A
     - cell_b_name: Name of cell type B
     """
+
     orthogonal_data = pd.DataFrame(
         {
             "Technology": [i for i in cell_a_with_b_cell_specific_genes for _ in range(2)],
@@ -468,7 +472,7 @@ def _create_barplot_visualization(
                 f"{cell_a_name} with {cell_b_name} genes",
                 f"{cell_b_name} with {cell_a_name} genes",
             ]
-            * 4,
+            * len(cell_a_with_b_cell_specific_genes.keys()),
             "Count": [
                 gene
                 for pair in zip(


### PR DESCRIPTION
This PR includes a few minor changes across the pre and qc modules:

1. In pre/__init__.py, fixed the order of function calls in add_custom_segmentation.
2. Took this opportunity to make some small fixes in the qc module as well.
3. In pre/boundary_tile.py, updated the logic to retain cell geometries in micron space instead of overriding them. This is necessary to compute average cell area in the qc module.

The changes have been tested by successfully running the following notebooks:

1. BNB_Streamlined_Pre_processing_Xenium_V1_Human_Pancreas_FFPE.ipynb
2. Custom_Segmentation.ipynb
3. Segmentation_QC.ipynb