### PR TITLE
Deprecate JSON network export

### DIFF
--- a/docs/overview/usage.md
+++ b/docs/overview/usage.md
@@ -25,4 +25,4 @@ cgm = dega.viz.Clustergram(parquet_data=pq_data, width=500, height=500)
 cgm
 ```
 
-`Clustergram` also accepts `network` or `matrix` arguments, but `parquet_data` is recommended for large datasets.
+`Clustergram` can also be initialized directly from a `Matrix` instance which internally uses `export_viz_parquet`. Passing a legacy JSON `network` is now deprecated.

--- a/docs/python/viz/api.md
+++ b/docs/python/viz/api.md
@@ -4,7 +4,8 @@
 
 The `Clustergram` widget accepts a `parquet_data` argument for efficient
 initialization. Use [`Matrix.export_viz_parquet`](../clust/api.md#celldega.clust.matrix.Matrix.export_viz_parquet)
-to generate this data from a clustered matrix.
+to generate this data from a clustered matrix. Passing a JSON ``network``
+object is deprecated; pass ``matrix`` or ``parquet_data`` instead.
 
 ::: celldega.viz
 

--- a/src/celldega/clust/matrix.py
+++ b/src/celldega/clust/matrix.py
@@ -621,17 +621,51 @@ class Matrix:
         return AnnData(X=self.data.values.T, obs=self.meta_col, var=self.meta_row)
 
     def export_viz_json(self) -> dict[str, Any]:
-        """Export visualization as JSON dict."""
+        """Export visualization as JSON dict.
+
+        .. deprecated:: 0.10
+           Use :meth:`export_viz_parquet` instead.
+        """
+        warnings.warn(
+            "`export_viz_json` is deprecated and will be removed in a future "
+            "release. Use `export_viz_parquet` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not self._clustered:
-            warnings.warn("Matrix not clustered. Call clust() first.", UserWarning, stacklevel=2)
+            warnings.warn(
+                "Matrix not clustered. Call clust() first.",
+                UserWarning,
+                stacklevel=2,
+            )
         return self.viz.copy()
 
     def export_viz_json_string(self) -> str:
-        """Export visualization as JSON string."""
+        """Export visualization as JSON string.
+
+        .. deprecated:: 0.10
+           Use :meth:`export_viz_parquet` instead.
+        """
+        warnings.warn(
+            "`export_viz_json_string` is deprecated and will be removed in a "
+            "future release. Use `export_viz_parquet` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return json.dumps(self.export_viz_json())
 
     def export_viz_to_widget(self, which_viz: str = "viz") -> str:
-        """Export visualization for widget."""
+        """Export visualization for widget.
+
+        .. deprecated:: 0.10
+           Use :class:`celldega.viz.Clustergram` with ``matrix`` instead.
+        """
+        warnings.warn(
+            "`export_viz_to_widget` is deprecated. Instantiate `Clustergram` "
+            "with `matrix` or `parquet_data` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.export_viz_json_string()
 
     def export_viz_parquet(self) -> dict[str, bytes]:

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -4,6 +4,7 @@ Widget module for interactive visualization components.
 
 from contextlib import suppress
 from pathlib import Path
+import warnings
 
 import anywidget
 import traitlets
@@ -103,7 +104,7 @@ class Clustergram(anywidget.AnyWidget):
     Args:
         value (int): The value traitlet.
         component (str): The component traitlet.
-        network (dict): The network traitlet.
+        network (dict): **Deprecated.** Use ``matrix`` or ``parquet_data``.
         click_info (dict): The click_info traitlet.
 
     Returns:
@@ -123,6 +124,13 @@ class Clustergram(anywidget.AnyWidget):
 
     def __init__(self, **kwargs):
         pq_data = kwargs.pop("parquet_data", None)
+
+        if "network" in kwargs:
+            warnings.warn(
+                "`network` argument is deprecated. Use `matrix` or `parquet_data` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Allow fallback via a 'matrix' kwarg
         if pq_data is None:

--- a/tests/unit/test_clust/test_matrix.py
+++ b/tests/unit/test_clust/test_matrix.py
@@ -350,12 +350,14 @@ class TestMatrix:
         mat.cluster()
         assert mat._clustered, "Matrix should be marked as clustered"
 
-        # Test export methods
-        json_str = mat.export_viz_json_string()
-        assert isinstance(json_str, str), "export_viz_json_string() should return string"
+        # Test export methods (deprecated JSON)
+        with pytest.deprecated_call():
+            json_str = mat.export_viz_json_string()
+        assert isinstance(json_str, str)
 
-        json_dict = mat.export_viz_json()
-        assert isinstance(json_dict, dict), "export_viz_json() should return dict"
+        with pytest.deprecated_call():
+            json_dict = mat.export_viz_json()
+        assert isinstance(json_dict, dict)
 
         # Test data export
         exported_df = mat.to_df()


### PR DESCRIPTION
## Summary
- mark `export_viz_json*` functions as deprecated
- warn when Clustergram is initialized with a `network`
- document that JSON network is deprecated
- update tests for new deprecation warnings

## Testing
- `pre-commit` *(fails: command not found)*
- `pip install pre-commit` *(fails: network access blocked)*
- `pytest -q -o addopts=''` *(fails: missing numpy)*

------
https://chatgpt.com/codex/tasks/task_b_686ee26f2ec8832a8871b52b5afc73f8