### PR TITLE
Add neighborhood parquet sync

### DIFF
--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -79,6 +79,8 @@ export const landscape_ist = async (
   height = 800,
   meta_cell = {},
   meta_cluster = {},
+  meta_nbhd = {},
+  nbhd_parquet = null,
   umap = {},
   landscape_state = 'spatial',
   segmentation = 'default',
@@ -182,17 +184,21 @@ export const landscape_ist = async (
         type: 'FeatureCollection',
         features: filt_features,
       };
+      viz_state.nbhd.meta = meta_nbhd;
+      viz_state.nbhd.parquet = nbhd_parquet;
     }
   } else {
     viz_state.nbhd.alpha_nbhd = false;
 
-    viz_state.nbhd.ini_feature_collection = {
-      type: 'FeatureCollection',
-      features: [],
-      inst_alpha: null,
-    };
-    viz_state.nbhd.feature_collection = viz_state.nbhd.ini_feature_collection;
-  }
+  viz_state.nbhd.ini_feature_collection = {
+    type: 'FeatureCollection',
+    features: [],
+    inst_alpha: null,
+  };
+  viz_state.nbhd.feature_collection = viz_state.nbhd.ini_feature_collection;
+  viz_state.nbhd.meta = meta_nbhd;
+  viz_state.nbhd.parquet = nbhd_parquet;
+}
 
   viz_state.containers = {};
   viz_state.containers.root_dim = {};

--- a/js/widget.js
+++ b/js/widget.js
@@ -23,6 +23,8 @@ const render_landscape_ist = async ({ model, el }) => {
   const height = model.get('height');
   const meta_cell = model.get('meta_cell');
   const meta_cluster = model.get('meta_cluster');
+  const meta_nbhd = model.get('meta_nbhd');
+  const nbhd_parquet = model.get('nbhd_parquet');
   const umap = model.get('umap');
   const landscape_state = model.get('landscape_state');
   const segmentation = model.get('segmentation');
@@ -42,6 +44,8 @@ const render_landscape_ist = async ({ model, el }) => {
     height,
     meta_cell,
     meta_cluster,
+    meta_nbhd,
+    nbhd_parquet,
     umap,
     landscape_state,
     segmentation,

--- a/src/celldega/nbhd/neighborhoods.py
+++ b/src/celldega/nbhd/neighborhoods.py
@@ -3,8 +3,12 @@
 # Standard library imports
 from itertools import combinations
 from typing import Any
+import io
+import numpy as np
 
 from anndata import AnnData
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 # Third-party imports
 import geopandas as gpd
@@ -262,6 +266,21 @@ class NBHD:
                 summary[subkey] = subval.shape if hasattr(subval, "shape") else None
             return summary
         return val.shape if hasattr(val, "shape") else None
+
+    def to_adata(self) -> AnnData:
+        """Return an AnnData representation of the neighborhoods."""
+        obs = self.gdf.drop(columns="geometry").copy()
+        coords = np.vstack(
+            [self.gdf.geometry.centroid.x.values, self.gdf.geometry.centroid.y.values]
+        ).T
+        adata = AnnData(obs=obs, obsm={"spatial": coords})
+        return adata
+
+    def export_parquet(self) -> bytes:
+        """Export the neighborhoods as Parquet-encoded bytes."""
+        buf = io.BytesIO()
+        pq.write_table(pa.Table.from_pandas(self.gdf), buf, compression="zstd")
+        return buf.getvalue()
 
 
 def calc_nbp(

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -59,6 +59,9 @@ class Landscape(anywidget.AnyWidget):
     region = traitlets.Dict({}).tag(sync=True)
     nbhd = traitlets.Dict({}).tag(sync=True)
 
+    meta_nbhd = traitlets.Dict({}).tag(sync=True)
+    nbhd_parquet = traitlets.Bytes(b"").tag(sync=True)
+
     meta_cell = traitlets.Dict({}).tag(sync=True)
     meta_cluster = traitlets.Dict({}).tag(sync=True)
     umap = traitlets.Dict({}).tag(sync=True)

--- a/tests/unit/test_nbhd/test_export_parquet.py
+++ b/tests/unit/test_nbhd/test_export_parquet.py
@@ -1,0 +1,21 @@
+import pytest
+
+try:
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+    from anndata import AnnData
+    from celldega.nbhd.neighborhoods import NBHD
+except Exception as e:  # pragma: no cover - if deps missing skip
+    pytest.skip(f"celldega modules unavailable: {e}", allow_module_level=True)
+
+
+def test_export_parquet_returns_bytes():
+    gdf = gpd.GeoDataFrame({
+        "name": ["a"],
+        "geometry": [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+    })
+    ad = AnnData()
+    nb = NBHD(gdf, nbhd_type="hex", adata=ad, data_dir="", path_landscape_files="")
+    data = nb.export_parquet()
+    assert isinstance(data, (bytes, bytearray))
+    assert data


### PR DESCRIPTION
## Summary
- support meta_nbhd and nbhd_parquet traits in widget
- allow neighborhoods to export Parquet and convert to AnnData
- propagate meta_nbhd/nbhd_parquet in JS landscape
- test neighborhood parquet export

## Testing
- `pytest -q --override-ini addopts="" tests/unit/test_nbhd/test_export_parquet.py` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_686f1126c780832aa5441f4330e140e5