### PR TITLE
moved mkdocs dependencies to dev install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pre-commit",        # Git hooks automation
     "build",             # Package building
     "twine",             # PyPI publishing
+    # Documentation dependencies
     "mkdocs",
     "mkdocs-material",
     "mkdocstrings[python]",


### PR DESCRIPTION
We can test that we can install following the instructions in https://github.com/broadinstitute/celldega/blob/main/CONTRIBUTING.md and run `mkdocs serve`