### PR TITLE
Implement deck cleanup on widget close

### DIFF
--- a/js/viz/matrix_viz.js
+++ b/js/viz/matrix_viz.js
@@ -147,4 +147,6 @@ export const matrix_viz = async (
 
   el.appendChild(ui_container);
   el.appendChild(viz_state.root);
+
+  return () => deck_mat.finalize();
 };

--- a/js/widget.js
+++ b/js/widget.js
@@ -134,11 +134,12 @@ const render_matrix_new = async ({ model, el }) => {
     );
   }
 
-  matrix_viz(model, el, network, width, height);
+  return matrix_viz(model, el, network, width, height);
 };
 
 // Main render function - no export keyword
-function render({ model, el }) {
+async function render({ model, el }) {
+  let cleanup = null;
   try {
     const componentType = model.get('component');
 
@@ -152,15 +153,32 @@ function render({ model, el }) {
 
     switch (componentType) {
       case 'Landscape':
-        return render_landscape({ model, el });
+        cleanup = await render_landscape({ model, el });
+        break;
       case 'Matrix':
-        return render_matrix_new({ model, el });
+        cleanup = await render_matrix_new({ model, el });
+        break;
       default:
         handleValidationWarning(`Unknown component type: ${componentType}`, {
           data: { componentType, model: model?.id || 'unknown' },
         });
         return;
     }
+
+    model.on('msg:custom', (msg) => {
+      if (msg.event === 'finalize' && cleanup) {
+        try {
+          if (typeof cleanup === 'function') {
+            cleanup();
+          } else if (cleanup.finalize) {
+            cleanup.finalize();
+          }
+        } catch (e) {
+          console.error('Error finalizing deck:', e);
+        }
+        cleanup = null;
+      }
+    });
   } catch (error) {
     const errorResult = handleAsyncError(error, {
       context: 'render function',

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -93,6 +93,12 @@ class Landscape(anywidget.AnyWidget):
         # Convert the new_clusters to a JSON serializable format if necessary
         self.cell_clusters = new_clusters
 
+    def close(self):  # pragma: no cover - cleanup depends on JS
+        """Close the widget and notify the frontend to release resources."""
+        with suppress(Exception):
+            self.send({"event": "finalize"})
+        super().close()
+
 
 class Clustergram(anywidget.AnyWidget):
     """
@@ -162,3 +168,9 @@ class Clustergram(anywidget.AnyWidget):
         kwargs["name"] = name
         super().__init__(**kwargs)
         _clustergram_registry[name] = self
+
+    def close(self):  # pragma: no cover - cleanup depends on JS
+        """Close the widget and notify the frontend to release resources."""
+        with suppress(Exception):
+            self.send({"event": "finalize"})
+        super().close()


### PR DESCRIPTION
## Summary
- send a finalize event from `Landscape` and `Clustergram` when closing
- return a cleanup function from `matrix_viz`
- handle finalize events in the widget renderer

## Testing
- `pre-commit run --files js/viz/matrix_viz.js js/widget.js src/celldega/viz/widget.py` *(fails: pre-commit not found)*
- `pytest` *(fails: pytest configuration requires missing plugins)*
- `npx prettier --write js/viz/matrix_viz.js js/widget.js`
- `npx eslint js/viz/matrix_viz.js js/widget.js` *(fails: cannot find package '@eslint/js')*
- `ruff check src/celldega/viz/widget.py --fix`
- `ruff format src/celldega/viz/widget.py`


------
https://chatgpt.com/codex/tasks/task_b_687013ab0b64832a95f3f92d070575a3