### PR TITLE
Add Enrichr widget

### DIFF
--- a/js/external_apis/enrichr_api.js
+++ b/js/external_apis/enrichr_api.js
@@ -1,0 +1,30 @@
+import { handleAsyncError } from '../temp_utils/errorHandler';
+
+export const postGeneList = async (genes) => {
+  const url = 'https://amp.pharm.mssm.edu/Enrichr/addList';
+  const formData = new FormData();
+  formData.append('list', genes.join('\n'));
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+    });
+    const json = await response.json();
+    return json.userListId.toString();
+  } catch (error) {
+    handleAsyncError(error, { context: 'posting gene list to Enrichr', url });
+    throw error;
+  }
+};
+
+export const fetchEnrichment = async (listId, library) => {
+  const url = `https://amp.pharm.mssm.edu/Enrichr/enrich?backgroundType=${library}&userListId=${listId}`;
+  try {
+    const response = await fetch(url);
+    return await response.json();
+  } catch (error) {
+    handleAsyncError(error, { context: 'fetching enrichment', url });
+    throw error;
+  }
+};

--- a/js/external_apis/refseq_api.js
+++ b/js/external_apis/refseq_api.js
@@ -1,0 +1,38 @@
+import { handleAsyncError } from '../temp_utils/errorHandler';
+
+export const refseq_cache = {};
+
+export const fetchRefSeqInfo = async (geneSymbol) => {
+  if (geneSymbol in refseq_cache) {
+    return refseq_cache[geneSymbol];
+  }
+
+  const searchUrl =
+    `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=gene&term=${geneSymbol}[sym]&retmode=json`;
+
+  try {
+    const searchRes = await fetch(searchUrl);
+    const searchJson = await searchRes.json();
+    const id = searchJson.esearchresult?.idlist?.[0];
+    if (!id) {
+      refseq_cache[geneSymbol] = null;
+      return null;
+    }
+
+    const summaryUrl =
+      `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=gene&id=${id}&retmode=json`;
+    const summaryRes = await fetch(summaryUrl);
+    const summaryJson = await summaryRes.json();
+    const doc = summaryJson.result?.[id] || {};
+    const info = {
+      name: doc.name || '',
+      description: doc.summary || '',
+      refseq: doc.genomicinfo?.[0]?.chraccver || '',
+    };
+    refseq_cache[geneSymbol] = info;
+    return info;
+  } catch (error) {
+    handleAsyncError(error, { context: 'fetchRefSeqInfo', url: searchUrl });
+    throw error;
+  }
+};

--- a/js/widget.js
+++ b/js/widget.js
@@ -8,6 +8,9 @@ import { landscape_h_e } from './viz/landscape_h_e';
 import { landscape_ist } from './viz/landscape_ist';
 import { landscape_sst } from './viz/landscape_sst';
 import { matrix_viz } from './viz/matrix_viz';
+import { postGeneList, fetchEnrichment } from './external_apis/enrichr_api';
+import { uniprot_data, uniprot_get_request } from './external_apis/uniprot_api';
+import { fetchRefSeqInfo } from './external_apis/refseq_api';
 
 // Remove export keywords from render functions
 const render_landscape_ist = async ({ model, el }) => {
@@ -137,6 +140,81 @@ const render_matrix_new = async ({ model, el }) => {
   matrix_viz(model, el, network, width, height);
 };
 
+const render_enrich = async ({ model, el }) => {
+  const container = document.createElement('div');
+  const tableHolder = document.createElement('div');
+  const geneInfoHolder = document.createElement('div');
+  container.appendChild(tableHolder);
+  container.appendChild(geneInfoHolder);
+  el.appendChild(container);
+
+  const update = async () => {
+    const genes = model.get('gene_list') || [];
+    const lib = model.get('inst_lib') || 'KEGG_2019_Human';
+    const numTerms = model.get('num_terms') || 10;
+
+    if (genes.length === 0) {
+      tableHolder.textContent = 'No genes provided.';
+      geneInfoHolder.textContent = '';
+      return;
+    }
+
+    tableHolder.textContent = 'Loading...';
+
+    try {
+      const listId = await postGeneList(genes);
+      const data = await fetchEnrichment(listId, lib);
+      const arr = (data[lib] || [])
+        .map((d) => ({ name: d[1], score: d[4], genes: d[5] }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, numTerms);
+
+      const table = document.createElement('table');
+      arr.forEach((term) => {
+        const row = document.createElement('tr');
+        const nameCell = document.createElement('td');
+        nameCell.textContent = term.name;
+        const scoreCell = document.createElement('td');
+        scoreCell.textContent = term.score.toFixed(2);
+        row.appendChild(nameCell);
+        row.appendChild(scoreCell);
+        row.addEventListener('click', () => {
+          geneInfoHolder.innerHTML = '';
+          term.genes.forEach((g) => {
+            const span = document.createElement('span');
+            span.textContent = `${g} `;
+            span.style.cursor = 'pointer';
+            span.addEventListener('click', async () => {
+              geneInfoHolder.textContent = 'loading...';
+              await uniprot_get_request(g);
+              const uni = uniprot_data[g] || {};
+              const ref = await fetchRefSeqInfo(g);
+              const infoParts = [];
+              if (uni.name) infoParts.push(`<strong>${uni.name}</strong>`);
+              if (uni.description) infoParts.push(uni.description);
+              if (ref?.refseq) infoParts.push(`RefSeq: ${ref.refseq}`);
+              geneInfoHolder.innerHTML = infoParts.join('<br>');
+            });
+            geneInfoHolder.appendChild(span);
+          });
+        });
+        table.appendChild(row);
+      });
+      tableHolder.innerHTML = '';
+      tableHolder.appendChild(table);
+    } catch (error) {
+      handleAsyncError(error, { context: 'render_enrich' });
+      tableHolder.textContent = 'Error loading enrichment data.';
+      geneInfoHolder.textContent = '';
+    }
+  };
+
+  model.on('change:gene_list', update);
+  model.on('change:inst_lib', update);
+  model.on('change:num_terms', update);
+  await update();
+};
+
 // Main render function - no export keyword
 function render({ model, el }) {
   try {
@@ -155,6 +233,8 @@ function render({ model, el }) {
         return render_landscape({ model, el });
       case 'Matrix':
         return render_matrix_new({ model, el });
+      case 'Enrich':
+        return render_enrich({ model, el });
       default:
         handleValidationWarning(`Unknown component type: ${componentType}`, {
           data: { componentType, model: model?.id || 'unknown' },
@@ -186,4 +266,5 @@ export default {
   render_landscape_h_e,
   render_landscape,
   render_matrix_new,
+  render_enrich,
 };

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -108,6 +108,12 @@ class Enrich(anywidget.AnyWidget):
     # gene list
     gene_list = traitlets.List([]).tag(sync=True)
 
+    # enrichment library
+    inst_lib = traitlets.Unicode("KEGG_2019_Human").tag(sync=True)
+
+    # number of terms
+    num_terms = traitlets.Int(10).tag(sync=True)
+
 
 class Clustergram(anywidget.AnyWidget):
     """

--- a/tests/unit/test_enrich/test_enrich_widget.py
+++ b/tests/unit/test_enrich/test_enrich_widget.py
@@ -1,0 +1,27 @@
+"""Tests for the Enrich widget traitlets."""
+
+import pytest
+
+try:
+    from celldega.viz import Enrich
+except Exception as e:  # pragma: no cover - skip if deps missing
+    pytest.skip(f"celldega modules unavailable: {e}", allow_module_level=True)
+
+
+def test_enrich_defaults() -> None:
+    w = Enrich()
+    assert w.component == "Enrich"
+    assert w.gene_list == []
+    assert w.inst_lib == "KEGG_2019_Human"
+    assert w.num_terms == 10
+
+
+def test_enrich_traitlets_update() -> None:
+    w = Enrich()
+    w.gene_list = ["A", "B"]
+    assert w.gene_list == ["A", "B"]
+    w.inst_lib = "GO_Biological_Process_2018"
+    assert w.inst_lib == "GO_Biological_Process_2018"
+    w.num_terms = 5
+    assert w.num_terms == 5
+


### PR DESCRIPTION
## Summary
- implement a basic Enrichr API module
- add a minimal Enrich widget in the JS bundle
- expose enrichment controls from Python side
- enhance Enrich widget to display gene details via UniProt and RefSeq APIs
- add unit tests for new Enrich widget traitlets

## Testing
- `pre-commit run --files js/widget.js js/external_apis/refseq_api.js js/external_apis/enrichr_api.js js/external_apis/uniprot_api.js src/celldega/viz/widget.py tests/unit/test_enrich/test_enrich_widget.py` *(fails: pre-commit not installed)*
- `pytest` *(fails: missing pytest-cov arguments)*


------
https://chatgpt.com/codex/tasks/task_b_68714336ef38832aba672c12e37aa2d4