### PR TITLE
Add Enrichr background list support

### DIFF
--- a/js/external_apis/enrichr_api.js
+++ b/js/external_apis/enrichr_api.js
@@ -1,9 +1,12 @@
 import { handleAsyncError } from '../temp_utils/errorHandler';
 
-export const postGeneList = async (genes) => {
+export const postGeneList = async (genes, background = null) => {
   const url = 'https://amp.pharm.mssm.edu/Enrichr/addList';
   const formData = new FormData();
   formData.append('list', genes.join('\n'));
+  if (background && Array.isArray(background) && background.length > 0) {
+    formData.append('background', background.join('\n'));
+  }
 
   try {
     const response = await fetch(url, {
@@ -11,7 +14,10 @@ export const postGeneList = async (genes) => {
       body: formData,
     });
     const json = await response.json();
-    return json.userListId.toString();
+    return {
+      userListId: json.userListId.toString(),
+      shortId: json.shortId || null,
+    };
   } catch (error) {
     handleAsyncError(error, { context: 'posting gene list to Enrichr', url });
     throw error;

--- a/js/widgets/enrich_widget.js
+++ b/js/widgets/enrich_widget.js
@@ -19,9 +19,11 @@ export const render_enrich = async ({ model, el }) => {
   const infoHolder = document.createElement('div');
   const geneInfoHolder = document.createElement('div');
   const paragraphHolder = document.createElement('div');
+  const linkHolder = document.createElement('a');
 
   container.appendChild(select);
   container.appendChild(layout);
+  container.appendChild(linkHolder);
   layout.appendChild(barHolder);
   layout.appendChild(infoHolder);
   infoHolder.appendChild(paragraphHolder);
@@ -57,6 +59,11 @@ export const render_enrich = async ({ model, el }) => {
   geneInfoHolder.style.overflowY = 'auto';
   geneInfoHolder.style.border = '1px solid #d3d3d3';
   geneInfoHolder.style.fontFamily = '-apple-system, BlinkMacSystemFont, "San Francisco", "Helvetica Neue", Helvetica, Arial, sans-serif';
+
+  linkHolder.style.display = 'block';
+  linkHolder.style.marginTop = '5px';
+  linkHolder.textContent = '';
+  linkHolder.target = '_blank';
 
   paragraphHolder.textContent = 'Paragraph view';
   geneInfoHolder.textContent = 'Gene info';
@@ -108,24 +115,29 @@ export const render_enrich = async ({ model, el }) => {
     const genes = model.get('gene_list') || [];
     const lib = store.selected_lib.get();
     const numTerms = model.get('num_terms') || 10;
+    const background = model.get('background_list') || null;
 
     if (genes.length === 0) {
       barHolder.textContent = 'No genes provided.';
       geneInfoHolder.textContent = '';
+      linkHolder.textContent = '';
       return;
     }
 
     barHolder.textContent = 'Loading...';
 
     try {
-      const cacheKey = `${genes.join(',')}__${lib}`;
+      const cacheKey = `${genes.join(',')}__${lib}__${background ? background.join(',') : 'none'}`;
       let data;
+      let shortId;
       if (cache[cacheKey]) {
-        data = cache[cacheKey];
+        ({ data, shortId } = cache[cacheKey]);
       } else {
-        const listId = await postGeneList(genes);
+        const res = await postGeneList(genes, background);
+        const listId = res.userListId;
+        shortId = res.shortId;
         data = await fetchEnrichment(listId, lib);
-        cache[cacheKey] = data;
+        cache[cacheKey] = { data, shortId };
       }
 
       const bar_data = (data[lib] || [])
@@ -265,15 +277,23 @@ export const render_enrich = async ({ model, el }) => {
       });
 
       updateParagraphColors(element, store.term_genes.get());
+      if (shortId) {
+        linkHolder.href = `https://maayanlab.cloud/Enrichr/enrich?dataset=${shortId}`;
+        linkHolder.textContent = 'View full results on Enrichr';
+      } else {
+        linkHolder.textContent = '';
+      }
     } catch (error) {
       handleAsyncError(error, { context: 'render_enrich' });
       barHolder.textContent = 'Error loading enrichment data.';
       geneInfoHolder.textContent = '';
+      linkHolder.textContent = '';
     }
   };
 
   model.on('change:gene_list', update);
   model.on('change:inst_lib', update);
   model.on('change:num_terms', update);
+  model.on('change:background_list', update);
   await update();
 };

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -127,6 +127,9 @@ class Enrich(anywidget.AnyWidget):
     # gene list
     gene_list = traitlets.List(default_value=[]).tag(sync=True)
 
+    # optional background gene list
+    background_list = traitlets.List(allow_none=True, default_value=None).tag(sync=True)
+
     # available enrichment libraries
     available_libs = traitlets.List(
         [

--- a/tests/unit/test_enrich/test_enrich_widget.py
+++ b/tests/unit/test_enrich/test_enrich_widget.py
@@ -16,6 +16,7 @@ def test_enrich_defaults() -> None:
     assert "KEGG_2019_Human" in w.available_libs
     assert w.inst_lib == "KEGG_2019_Human"
     assert w.num_terms == 10
+    assert w.background_list is None
 
 
 def test_enrich_traitlets_update() -> None:
@@ -28,4 +29,6 @@ def test_enrich_traitlets_update() -> None:
     assert w.available_libs == ["A", "B"]
     w.num_terms = 5
     assert w.num_terms == 5
+    w.background_list = ["X", "Y"]
+    assert w.background_list == ["X", "Y"]
 


### PR DESCRIPTION
## Summary
- allow specifying a background gene list when posting to Enrichr
- expose permanent Enrichr result link in the enrichment widget
- support `background_list` traitlet in Enrich widget
- test the new traitlet

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: environment tried to fetch npm packages)*

------
https://chatgpt.com/codex/tasks/task_b_6873bd9872d4832ab1b9a47456cdadfa