### PR TITLE
Add micron neighborhood workflow with AnnData

### DIFF
--- a/notebooks/Mouse-Brain_Alpha-Shape-Neighborhood-AnnData.ipynb
+++ b/notebooks/Mouse-Brain_Alpha-Shape-Neighborhood-AnnData.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mouse Brain Alpha Shape Neighborhoods using AnnData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import scanpy as sc\n",
+    "import pandas as pd\n",
+    "import celldega as dega"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "base_path = 'https://raw.githubusercontent.com/broadinstitute/celldega_Xenium_Prime_Mouse_Brain_Coronal_FF_outs/main/Xenium_Prime_Mouse_Brain_Coronal_FF_outs/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "adata = sc.read_h5ad(base_path + 'mouse_brain.h5ad')\n",
+    "meta_cluster = pd.read_parquet(base_path + 'cell_clusters/meta_cluster.parquet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "gdf_alpha = dega.nbhd.alpha_shape_cell_clusters_from_adata(adata)\n",
+    "dega.nbhd.save_nbhd_to_parquet(gdf_alpha, 'alpha_shapes.parquet', base_path + 'micron_to_image_transform.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "geojson_alpha = dega.nbhd.alpha_shape_geojson(gdf_alpha, meta_cluster, inst_alpha=250)\n",
+    "base_url = base_path.rstrip('/')\n",
+    "dega.viz.Landscape(technology='Xenium', ini_zoom=-4.5, ini_x=6000, ini_y=8000, base_url=base_url, nbhd=geojson_alpha)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/celldega/nbhd/__init__.py
+++ b/src/celldega/nbhd/__init__.py
@@ -1,6 +1,10 @@
 """Module for performing neighborhood analysis."""
 
-from .alpha_shapes import alpha_shape, alpha_shape_cell_clusters
+from .alpha_shapes import (
+    alpha_shape,
+    alpha_shape_cell_clusters,
+    alpha_shape_cell_clusters_from_adata,
+)
 from .gradient import calc_grad_nbhd_from_roi
 from .hextile import generate_hex_grid
 from .neighborhoods import (
@@ -16,6 +20,8 @@ from .utils import (
     _get_df_cell,
     _get_gdf_cell,
     _get_gdf_trx,
+    get_gdf_cell_from_adata,
+    save_nbhd_to_parquet,
 )
 
 
@@ -25,6 +31,9 @@ __all__ = [
     "_get_df_cell",
     "_get_gdf_cell",
     "_get_gdf_trx",
+    "get_gdf_cell_from_adata",
+    "alpha_shape_cell_clusters_from_adata",
+    "save_nbhd_to_parquet",
     "alpha_shape",
     "alpha_shape_cell_clusters",
     "calc_grad_nbhd_from_roi",

--- a/src/celldega/nbhd/alpha_shapes.py
+++ b/src/celldega/nbhd/alpha_shapes.py
@@ -11,7 +11,11 @@ from libpysal.cg import alpha_shape as libpysal_alpha_shape
 import numpy as np
 from shapely.geometry import MultiPolygon, Point, base, shape
 
-from .utils import _classify_polygons_contains_check, _round_coordinates
+from .utils import (
+    _classify_polygons_contains_check,
+    _round_coordinates,
+    get_gdf_cell_from_adata,
+)
 
 
 def _verify_polygons_with_alpha_bulk(
@@ -101,6 +105,18 @@ def alpha_shape_cell_clusters(
     )
     gdf_alpha["area"] = gdf_alpha.area
     return gdf_alpha.loc[gdf_alpha.area.sort_values(ascending=False).index.tolist()]
+
+
+def alpha_shape_cell_clusters_from_adata(
+    adata: Any,
+    key: str = "spatial",
+    cluster_key: str = "leiden",
+    alphas: Sequence[float] = (100, 150, 200, 250, 300, 350),
+) -> gpd.GeoDataFrame:
+    """Convenience wrapper to compute alpha shapes directly from an AnnData object."""
+
+    gdf_cell = get_gdf_cell_from_adata(adata, key=key, cluster_key=cluster_key)
+    return alpha_shape_cell_clusters(gdf_cell, cat="cluster", alphas=alphas)
 
 
 def alpha_shape_geojson(

--- a/src/celldega/nbhd/utils.py
+++ b/src/celldega/nbhd/utils.py
@@ -11,6 +11,11 @@ import pandas as pd
 from shapely.geometry import Point, base
 from shapely.ops import transform
 
+from celldega.pre.boundary_tile import (
+    _round_nested_coord_list,
+    batch_transform_geometries,
+)
+
 
 def _add_centroids_to_obsm(
     adata: Any,
@@ -121,3 +126,71 @@ def _round_coordinates(
         return (round(x, precision), round(y, precision))
 
     return transform(round_coords, geometry)
+
+
+def get_gdf_cell_from_adata(
+    adata: Any,
+    key: str = "spatial",
+    cluster_key: str = "leiden",
+) -> gpd.GeoDataFrame:
+    """Return cell coordinates from an :class:`~anndata.AnnData` object as a
+    :class:`geopandas.GeoDataFrame`.
+
+    Parameters
+    ----------
+    adata:
+        AnnData object with spatial coordinates stored in ``adata.obsm[key]``.
+    key:
+        Key in ``adata.obsm`` where the spatial coordinates are stored.
+    cluster_key:
+        Column in ``adata.obs`` containing cluster labels. Defaults to
+        ``"leiden"``.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        GeoDataFrame with cell clusters (if present) and point geometries.
+    """
+
+    clusters = adata.obs.get(cluster_key)
+    return gpd.GeoDataFrame(
+        {"cluster": clusters} if clusters is not None else {},
+        geometry=gpd.points_from_xy(*adata.obsm[key].T[:2]),
+        crs="EPSG:4326",
+    )
+
+
+def save_nbhd_to_parquet(
+    gdf_nbhd: gpd.GeoDataFrame,
+    path_output: str,
+    transformation_matrix: np.ndarray | str,
+    image_scale: float = 1,
+) -> None:
+    """Save neighborhoods to a Parquet file after converting from micron to
+    image (Parquet) space.
+
+    Parameters
+    ----------
+    gdf_nbhd:
+        Neighborhood polygons in micron coordinates.
+    path_output:
+        Destination Parquet file.
+    transformation_matrix:
+        3x3 affine matrix or path to ``micron_to_image_transform.csv``.
+    image_scale:
+        Scale factor applied after the affine transformation.
+    """
+
+    if isinstance(transformation_matrix, str):
+        transformation_matrix = pd.read_csv(
+            transformation_matrix, header=None, sep=" "
+        ).values
+
+    transformed = batch_transform_geometries(
+        gdf_nbhd["geometry"], transformation_matrix, image_scale
+    )
+    df = gdf_nbhd.copy()
+    df["GEOMETRY"] = [coords for coords in transformed]
+    df["GEOMETRY"] = df["GEOMETRY"].apply(lambda x: _round_nested_coord_list(x))
+    df.drop(columns=["geometry"], inplace=True)
+    df.to_parquet(path_output, index=False)


### PR DESCRIPTION
## Summary
- add `alpha_shape_cell_clusters_from_adata` to compute alpha shapes directly from an AnnData object
- expose cluster key in `get_gdf_cell_from_adata`
- export new utilities in `celldega.nbhd`
- provide example notebook computing neighborhoods in micron space and saving to Parquet

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=src/celldega --cov-report=html --cov-report=term-missing --cov-report=xml)*

------
https://chatgpt.com/codex/tasks/task_b_68785e9a926c832a82e14244053e9f1d