### PR TITLE
Orchestrate layer updates with deck_ready

### DIFF
--- a/js/ui/sliders.js
+++ b/js/ui/sliders.js
@@ -31,8 +31,17 @@ const cell_slider_callback = async (deck_ist, layers_obj, viz_state) => {
     viz_state.sliders.cell.value / scale_down_cell_radius
   );
 
-  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-  deck_ist.setProps({ layers: layers_list });
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: false,
+  });
+
+  viz_state.layers_obj = layers_obj;
+
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: true,
+  });
 };
 
 const trx_slider_callback = async (deck_ist, layers_obj, viz_state) => {
@@ -43,8 +52,17 @@ const trx_slider_callback = async (deck_ist, layers_obj, viz_state) => {
     viz_state.sliders.trx.value / scale_down_trx_radius
   );
 
-  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-  deck_ist.setProps({ layers: layers_list });
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    trx_layer: false,
+  });
+
+  viz_state.layers_obj = layers_obj;
+
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    trx_layer: true,
+  });
 };
 
 export const make_img_layer_slider_callback = (
@@ -70,8 +88,17 @@ export const make_img_layer_slider_callback = (
       viz_state.img.image_layer_colors
     );
 
-    const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-    deck_ist.setProps({ layers: layers_list });
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      image_layers: false,
+    });
+
+    viz_state.layers_obj = layers_obj;
+
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      image_layers: true,
+    });
   };
 };
 

--- a/js/ui/text_buttons.js
+++ b/js/ui/text_buttons.js
@@ -11,7 +11,6 @@ import { square_scatter_layer_visibility } from '../deck-gl/layers/square_scatte
 import { toggle_trx_layer_visibility } from '../deck-gl/layers/trx_layer';
 import { toggle_dendro_layer_visibility } from '../deck-gl/matrix/dendro_layers';
 import { get_mat_layers_list } from '../deck-gl/matrix/matrix_layers';
-import { get_layers_list } from '../deck-gl/utils/layers_ist';
 
 import { toggle_slider } from './sliders';
 
@@ -213,8 +212,17 @@ const trx_button_callback_ist = async (
 
   toggle_trx_layer_visibility(layers_obj, is_visible);
 
-  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-  deck_ist.setProps({ layers: layers_list });
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    trx_layer: false,
+  });
+
+  viz_state.layers_obj = layers_obj;
+
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    trx_layer: true,
+  });
 };
 
 const cell_button_callback = async (event, deck_ist, layers_obj, viz_state) => {
@@ -225,8 +233,19 @@ const cell_button_callback = async (event, deck_ist, layers_obj, viz_state) => {
   new_toggle_cell_layer_visibility(layers_obj, is_visible);
   toggle_path_layer_visibility(layers_obj, is_visible);
 
-  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-  deck_ist.setProps({ layers: layers_list });
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: false,
+    path_layer: false,
+  });
+
+  viz_state.layers_obj = layers_obj;
+
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: true,
+    path_layer: true,
+  });
 };
 
 const umap_button_callback = async (event, deck_ist, layers_obj, viz_state) => {
@@ -241,8 +260,21 @@ const umap_button_callback = async (event, deck_ist, layers_obj, viz_state) => {
   toggle_trx_layer_visibility(layers_obj, false);
   toggle_path_layer_visibility(layers_obj, false);
 
-  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-  deck_ist.setProps({ layers: layers_list });
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: false,
+    path_layer: false,
+    trx_layer: false,
+  });
+
+  viz_state.layers_obj = layers_obj;
+
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: true,
+    path_layer: true,
+    trx_layer: true,
+  });
 };
 
 const spatial_button_callback = async (
@@ -258,15 +290,28 @@ const spatial_button_callback = async (
   viz_state.buttons.buttons.spatial.style('color', 'blue');
 
   // restore layer visibility after a short delay
-  setTimeout(() => {
-    viz_state.obs_store.viz_background_layer.set(true);
-    viz_state.obs_store.viz_image_layers.set(true);
-    toggle_trx_layer_visibility(layers_obj, true);
-    toggle_path_layer_visibility(layers_obj, true);
+    setTimeout(() => {
+      viz_state.obs_store.viz_background_layer.set(true);
+      viz_state.obs_store.viz_image_layers.set(true);
+      toggle_trx_layer_visibility(layers_obj, true);
+      toggle_path_layer_visibility(layers_obj, true);
 
-    const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-    deck_ist.setProps({ layers: layers_list });
-  }, 3000);
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: false,
+        path_layer: false,
+        trx_layer: false,
+      });
+
+      viz_state.layers_obj = layers_obj;
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: true,
+        path_layer: true,
+        trx_layer: true,
+      });
+    }, 3000);
 };
 
 const make_ist_img_layer_button_callback = (
@@ -287,8 +332,17 @@ const make_ist_img_layer_button_callback = (
 
       toggle_slider(inst_slider, is_visible);
 
-      const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-      deck_ist.setProps({ layers: layers_list });
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        image_layers: false,
+      });
+
+      viz_state.layers_obj = layers_obj;
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        image_layers: true,
+      });
     }
   };
 };

--- a/js/ui/ui_containers.js
+++ b/js/ui/ui_containers.js
@@ -467,15 +467,33 @@ export const make_ist_ui_container = (
 
     toggle_visibility_image_layers(layers_obj, viz_image_layers);
 
-    const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-    deck_ist.setProps({ layers: layers_list });
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      image_layers: false,
+    });
+
+    viz_state.layers_obj = layers_obj;
+
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      image_layers: true,
+    });
   });
 
   viz_state.obs_store.viz_background_layer.subscribe((visible) => {
     toggle_background_layer_visibility(layers_obj, visible);
 
-    const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-    deck_ist.setProps({ layers: layers_list });
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      background_layer: false,
+    });
+
+    viz_state.layers_obj = layers_obj;
+
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      background_layer: true,
+    });
   });
 
   make_button(

--- a/js/widget_interactions/update_cell_clusters.js
+++ b/js/widget_interactions/update_cell_clusters.js
@@ -1,4 +1,3 @@
-import { get_layers_list } from '../deck-gl/utils/layers_ist';
 import { update_cell_cats } from '../global_variables/cat';
 import { update_meta_cluster } from '../global_variables/meta_cluster';
 
@@ -8,8 +7,19 @@ export const update_cell_clusters = (deck_ist, layers_obj, viz_state) => {
   update_meta_cluster(viz_state.cats, new_cluster_info['meta_cluster']);
   update_cell_cats(viz_state.cats, new_cluster_info['new_clusters']);
 
-  const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-  deck_ist.setProps({ layers: layers_list });
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: false,
+    path_layer: false,
+  });
+
+  viz_state.layers_obj = layers_obj;
+
+  viz_state.obs_store.deck_check.set({
+    ...viz_state.obs_store.deck_check.get(),
+    cell_layer: true,
+    path_layer: true,
+  });
 
   viz_state.combo_data.cell = viz_state.combo_data.cell.map((cell) => ({
     ...cell,

--- a/js/widget_interactions/update_ist_landscape_from_cgm.js
+++ b/js/widget_interactions/update_ist_landscape_from_cgm.js
@@ -1,4 +1,3 @@
-import { get_layers_list } from '../deck-gl/utils/layers_ist';
 import { update_cat, update_selected_cats } from '../global_variables/cat';
 import { update_cell_exp_array } from '../global_variables/cell_exp_array';
 import { update_selected_genes } from '../global_variables/selected_genes';
@@ -40,8 +39,12 @@ export const update_ist_landscape_from_cgm = async (
         viz_state.aws
       );
 
-      const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-      deck_ist.setProps({ layers: layers_list });
+      viz_state.layers_obj = layers_obj;
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: true,
+      });
     } else if (click_info.type === 'col_label') {
       inst_gene = 'cluster';
       new_cat = click_info.value.name;
@@ -50,8 +53,12 @@ export const update_ist_landscape_from_cgm = async (
       update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
       update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-      deck_ist.setProps({ layers: layers_list });
+      viz_state.layers_obj = layers_obj;
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: true,
+      });
     } else if (click_info.type === 'col_dendro') {
       inst_gene = 'cluster';
 
@@ -62,8 +69,12 @@ export const update_ist_landscape_from_cgm = async (
       update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
       update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-      deck_ist.setProps({ layers: layers_list });
+      viz_state.layers_obj = layers_obj;
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: true,
+      });
 
       update_cat(viz_state.cats, inst_gene);
       update_selected_cats(


### PR DESCRIPTION
## Summary
- route cell and transcript slider changes through `deck_ready`
- update deck state on button interactions via deck observables
- trigger image/background layer visibility through observables
- ensure cell cluster updates rely on `deck_ready`
- handle CGM driven landscape updates with `deck_ready`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68792379c004832aa57aed5a0b7f33c2