### PR TITLE
Use Arrow for path layer

### DIFF
--- a/js/deck-gl/layers/path_layer.js
+++ b/js/deck-gl/layers/path_layer.js
@@ -4,8 +4,8 @@ import { update_selected_cats, update_cat } from '../../global_variables/cat';
 import { update_selected_genes } from '../../global_variables/selected_genes';
 import { grab_cell_tiles_in_view } from '../../vector_tile/polygons/grab_cell_tiles_in_view';
 
-export const get_path_color = (cats, i, d) => {
-  const inst_cell_id = cats.polygon_cell_names[d.index];
+export const get_path_color = (cats, i) => {
+  const inst_cell_id = cats.polygon_cell_names[i];
   const inst_cat = cats.dict_cell_cats[inst_cell_id];
 
   let inst_color;
@@ -33,8 +33,7 @@ export const ini_path_layer = (viz_state) => {
     pickable: true,
     widthScale: 3,
     widthMinPixels: 1,
-    getPath: (d) => d,
-    getColor: (i, d) => get_path_color(viz_state.cats, i, d),
+    getColor: (i) => get_path_color(viz_state.cats, i),
     widthUnits: 'pixels',
   });
 
@@ -69,14 +68,25 @@ export const update_path_layer_data = async (
   layers_obj,
   viz_state
 ) => {
-  const polygonPathsConcat = await grab_cell_tiles_in_view(
+  const polygonData = await grab_cell_tiles_in_view(
     base_url,
     tiles_in_view,
     viz_state
   );
 
+  const data = {
+    length: polygonData.length,
+    startIndices: polygonData.startIndices,
+    attributes: {
+      getPath: {
+        value: polygonData.attributes.getPolygon.value,
+        size: 2,
+      },
+    },
+  };
+
   layers_obj.path_layer = layers_obj.path_layer.clone({
-    data: polygonPathsConcat,
+    data,
   });
 
   // ensure state updated prior to deck_ready notification
@@ -90,8 +100,8 @@ export const update_path_layer_data = async (
 
 export const set_path_layer_onclick = (deck_ist, layers_obj, viz_state) => {
   layers_obj.path_layer = layers_obj.path_layer.clone({
-    onClick: (info, d) =>
-      path_layer_onclick(info, d, deck_ist, layers_obj, viz_state),
+    onClick: (info) =>
+      path_layer_onclick(info, null, deck_ist, layers_obj, viz_state),
   });
 };
 

--- a/js/vector_tile/polygons/grab_cell_tiles_in_view.js
+++ b/js/vector_tile/polygons/grab_cell_tiles_in_view.js
@@ -3,7 +3,6 @@ import { fetch_all_tables_new } from '../../read_parquet/fetch_all_tables';
 import { get_polygon_data } from '../../read_parquet/get_polygon_data';
 import { concatenate_polygon_data } from '../concatenate_functions';
 
-import { extractPolygonPaths } from './extractPolygonPaths';
 
 export const grab_cell_tiles_in_view = async (
   base_url,
@@ -50,7 +49,5 @@ export const grab_cell_tiles_in_view = async (
 
   const polygon_data = concatenate_polygon_data(polygon_datas);
 
-  const polygonPathsConcat = extractPolygonPaths(polygon_data);
-
-  return polygonPathsConcat;
+  return polygon_data;
 };


### PR DESCRIPTION
## Summary
- pass polygon data in Arrow format instead of GeoJSON
- read Arrow data in the path layer without creating JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68797cd9bdb4832a97f589b25961ee4a