### PR TITLE
Use Arrow for neighborhood geometries

### DIFF
--- a/js/deck-gl/layers/nbhd_layer.js
+++ b/js/deck-gl/layers/nbhd_layer.js
@@ -1,87 +1,52 @@
-// to do: re-enable nbhd layer
+import { SolidPolygonLayer } from 'deck.gl';
+import { hexToRgb } from '../../utils/hexToRgb';
+import { update_selected_cats, update_cat } from '../../global_variables/cat';
+import { update_selected_genes } from '../../global_variables/selected_genes';
 
-// // /* eslint-disable import/no-cycle */
+export const ini_nbhd_layer = (viz_state, visible) => {
+  const nbhd_layer = new SolidPolygonLayer({
+    id: 'nbhd-layer',
+    data: viz_state.nbhd.polygon_data,
+    pickable: true,
+    stroked: false,
+    filled: true,
+    getPolygon: (d) => d,
+    getFillColor: (i) => hexToRgb(viz_state.nbhd.colors[i] || '#000000'),
+    opacity: 0.5,
+    visible,
+  });
 
-// import { GeoJsonLayer } from 'deck.gl';
+  return nbhd_layer;
+};
 
-// import { update_selected_cats, update_cat } from '../../global_variables/cat';
-// import { update_selected_genes } from '../../global_variables/selected_genes';
-// import { hexToRgb } from '../../utils/hexToRgb';
-// import { get_layers_list } from '../utils/layers_ist';
+export const update_nbhd_layer_data = (viz_state, layers_obj) => {
+  layers_obj.nbhd_layer = layers_obj.nbhd_layer.clone({
+    data: viz_state.nbhd.polygon_data,
+  });
+};
 
-// export const ini_nbhd_layer = (viz_state, visible) => {
-//   // console.log(viz_state.nbhd.feature_collection)
+const nbhd_layer_onclick = (
+  info,
+  _event,
+  _deck_ist,
+  _layers_obj,
+  viz_state
+) => {
+  const inst_cat = viz_state.nbhd.cats[info.index];
+  update_cat(viz_state.cats, 'cluster');
+  update_selected_cats(viz_state.cats, [inst_cat], viz_state.obs_store);
+  update_selected_genes(viz_state.genes, [], viz_state.obs_store);
+};
 
-//   const nbhd_layer = new GeoJsonLayer({
-//     id: 'nbhd-layer',
-//     data: viz_state.nbhd.feature_collection,
-//     pickable: true,
-//     stroked: false,
-//     filled: true,
-//     getLineWidth: 1,
-//     getFillColor: (d) => hexToRgb(d.properties.color),
-//     opacity: 0.5,
-//     visible,
-//   });
+export const set_nbhd_layer_onclick = (deck_ist, layers_obj, viz_state) => {
+  layers_obj.nbhd_layer = layers_obj.nbhd_layer.clone({
+    onClick: (info, event) =>
+      nbhd_layer_onclick(info, event, deck_ist, layers_obj, viz_state),
+  });
+};
 
-//   return nbhd_layer;
-// };
-
-// export const filter_cat_nbhd_feature_collection = (viz_state) => {
-//   let filt_features;
-
-//   if (viz_state.cats.selected_cats.length === 0) {
-//     filt_features = viz_state.nbhd.ini_feature_collection.features.filter(
-//       (d) => d.properties.inv_alpha === viz_state.nbhd.inst_alpha
-//     );
-//   } else {
-//     filt_features = viz_state.nbhd.ini_feature_collection.features
-//       .filter((d) => viz_state.cats.selected_cats.includes(d.properties.cat))
-//       .filter((d) => d.properties.inv_alpha === viz_state.nbhd.inst_alpha);
-//   }
-//   viz_state.nbhd.feature_collection = {
-//     type: 'FeatureCollection',
-//     features: filt_features,
-//   };
-// };
-
-// export const update_nbhd_layer_data = (viz_state, layers_obj) => {
-//   layers_obj.nbhd_layer = layers_obj.nbhd_layer.clone({
-//     data: viz_state.nbhd.feature_collection,
-//   });
-// };
-
-// const nbhd_layer_onclick = async (
-//   info,
-//   _event,
-//   deck_ist,
-//   layers_obj,
-//   viz_state
-// ) => {
-//   const inst_cat = info.object.properties.cat;
-
-//   update_cat(viz_state.cats, 'cluster');
-//   update_selected_cats(viz_state.cats, [inst_cat], viz_state.obs_store);
-//   update_selected_genes(viz_state.genes, [], viz_state.obs_store);
-
-//   // update data for nbhd layer
-//   await filter_cat_nbhd_feature_collection(viz_state);
-//   await update_nbhd_layer_data(viz_state, layers_obj);
-
-//   const layers_list = get_layers_list(layers_obj, viz_state.close_up);
-//   deck_ist.setProps({ layers: layers_list });
-
-// };
-
-// export const set_nbhd_layer_onclick = (deck_ist, layers_obj, viz_state) => {
-//   layers_obj.nbhd_layer = layers_obj.nbhd_layer.clone({
-//     onClick: (info, event) =>
-//       nbhd_layer_onclick(info, event, deck_ist, layers_obj, viz_state),
-//   });
-// };
-
-// export const toggle_nbhd_layer_visibility = (layers_obj, visible) => {
-//   layers_obj.nbhd_layer = layers_obj.nbhd_layer.clone({
-//     visible,
-//   });
-// };
+export const toggle_nbhd_layer_visibility = (layers_obj, visible) => {
+  layers_obj.nbhd_layer = layers_obj.nbhd_layer.clone({
+    visible,
+  });
+};

--- a/js/deck-gl/utils/tooltips.js
+++ b/js/deck-gl/utils/tooltips.js
@@ -53,9 +53,9 @@ export const make_tooltip = (viz_state, info) => {
   // Handle neighborhood layer tooltips
   else if (info.layer.id.startsWith('nbhd-layer')) {
     inst_name =
-      viz_state.nbhd.feature_collection.features[info.index].properties.name;
+      viz_state.nbhd.names[info.index];
     inst_cat =
-      viz_state.nbhd.feature_collection.features[info.index].properties.cat;
+      viz_state.nbhd.cats[info.index];
     inst_html = `<div>neighborhood: ${inst_name}</div><div>cluster: ${inst_cat}</div>`;
   }
 

--- a/js/read_parquet/polygon_data_from_parquet.js
+++ b/js/read_parquet/polygon_data_from_parquet.js
@@ -1,0 +1,17 @@
+import { arrayBufferToArrowTable } from './arrayBufferToArrowTable';
+import { get_polygon_data } from './get_polygon_data';
+
+export const polygonDataFromParquet = async (bytes) => {
+  const table = await arrayBufferToArrowTable(bytes.buffer);
+  const polygonData = get_polygon_data(table);
+  if (!polygonData) return null;
+
+  const fields = table.schema.fields.map((f) => f.name);
+  const propFields = fields.slice(1); // assume geometry column first
+  const properties = {};
+  for (const f of propFields) {
+    properties[f] = table.getChild(f).toArray();
+  }
+
+  return { polygonData, properties };
+};

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -21,10 +21,10 @@ import {
 //   set_edit_layer_on_edit,
 // } from '../deck-gl/layers/edit_layer';
 import { make_image_layers } from '../deck-gl/layers/image_layers';
-// import {
-//   ini_nbhd_layer,
-//   set_nbhd_layer_onclick,
-// } from '../deck-gl/layers/nbhd_layer';
+import {
+  ini_nbhd_layer,
+  set_nbhd_layer_onclick,
+} from '../deck-gl/layers/nbhd_layer';
 import {
   ini_path_layer,
   set_path_layer_onclick,
@@ -76,7 +76,7 @@ export const landscape_ist = async (
   meta_cell_attr = [],
   meta_cluster = {},
   meta_cluster_attr = [],
-  nbhd_fc = null,
+  nbhd_data = null,
   nbhd_meta = {},
   nbhd_meta_attr = [],
   // meta_cluster_attr = [],
@@ -160,59 +160,19 @@ export const landscape_ist = async (
     viz_state.aws = null;
   }
 
-  if (nbhd_fc) {
+  if (nbhd_data) {
     viz_state.nbhd.alpha_nbhd = true;
-
-    viz_state.nbhd.ini_feature_collection = nbhd_fc;
-
-    viz_state.nbhd.inst_alpha = nbhd_fc['inst_alpha'];
-
-    const filt_features = nbhd_fc.features.filter(
-      (d) => d.properties.inv_alpha === viz_state.nbhd.inst_alpha
-    );
-
-    viz_state.nbhd.feature_collection = {
-      type: 'FeatureCollection',
-      features: filt_features,
-    };
-  } else if (Object.keys(viz_state.model).length !== 0) {
-    if (Object.keys(viz_state.model.get('nbhd')).length === 0) {
-      viz_state.nbhd.alpha_nbhd = false;
-
-      viz_state.nbhd.ini_feature_collection = {
-        type: 'FeatureCollection',
-        features: [],
-        inst_alpha: null,
-      };
-      viz_state.nbhd.feature_collection = viz_state.nbhd.ini_feature_collection;
-    } else {
-      viz_state.nbhd.alpha_nbhd = true;
-
-      viz_state.nbhd.ini_feature_collection = viz_state.model.get('nbhd');
-
-      viz_state.nbhd.inst_alpha =
-        viz_state.nbhd.ini_feature_collection['inst_alpha'];
-
-      const filt_features =
-        viz_state.nbhd.ini_feature_collection.features.filter(
-          (d) => d.properties.inv_alpha === viz_state.nbhd.inst_alpha
-        );
-
-      // filter for alpha shapes that have a inv_alpha value of 200
-      viz_state.nbhd.feature_collection = {
-        type: 'FeatureCollection',
-        features: filt_features,
-      };
-    }
+    viz_state.nbhd.polygon_data = nbhd_data.polygonData;
+    const props = nbhd_data.properties || {};
+    viz_state.nbhd.names = Array.from(props.name || []);
+    viz_state.nbhd.cats = Array.from(props.cat || []);
+    viz_state.nbhd.colors = Array.from(props.color || []);
   } else {
     viz_state.nbhd.alpha_nbhd = false;
-
-    viz_state.nbhd.ini_feature_collection = {
-      type: 'FeatureCollection',
-      features: [],
-      inst_alpha: null,
-    };
-    viz_state.nbhd.feature_collection = viz_state.nbhd.ini_feature_collection;
+    viz_state.nbhd.polygon_data = { length: 0, startIndices: new Int32Array(), attributes: { getPolygon: { value: new Float64Array(), size: 2 } } };
+    viz_state.nbhd.names = [];
+    viz_state.nbhd.cats = [];
+    viz_state.nbhd.colors = [];
   }
 
   viz_state.containers = {};
@@ -376,7 +336,7 @@ export const landscape_ist = async (
   const path_layer = await ini_path_layer(viz_state);
   const trx_layer = ini_trx_layer(viz_state.genes);
   // const edit_layer = ini_edit_layer(viz_state);
-  // const nbhd_layer = ini_nbhd_layer(viz_state, false);
+  const nbhd_layer = ini_nbhd_layer(viz_state, false);
 
   // make layers object
   const layers_obj = {
@@ -385,8 +345,8 @@ export const landscape_ist = async (
     cell_layer,
     path_layer,
     trx_layer,
+    nbhd_layer,
     // edit_layer,
-    // nbhd_layer,
   };
 
   viz_state.layers_obj = layers_obj;
@@ -397,7 +357,7 @@ export const landscape_ist = async (
   set_trx_layer_onclick(deck_ist, layers_obj, viz_state);
   // set_edit_layer_on_edit(deck_ist, layers_obj, viz_state);
   // set_edit_layer_on_click(deck_ist, layers_obj, viz_state);
-  // set_nbhd_layer_onclick(deck_ist, layers_obj, viz_state);
+  set_nbhd_layer_onclick(deck_ist, layers_obj, viz_state);
 
   viz_state.obs_store.deck_ready.subscribe((ready) => {
     if (ready) {

--- a/js/widget.js
+++ b/js/widget.js
@@ -2,7 +2,7 @@ import './widget.css';
 
 import { networkFromParquet } from './read_parquet/network_from_parquet';
 import { objects_from_parquet } from './read_parquet/objects_from_parquet';
-import { featureCollectionFromParquet } from './read_parquet/feature_collection_from_parquet';
+import { polygonDataFromParquet } from './read_parquet/polygon_data_from_parquet';
 import {
   handleAsyncError,
   handleValidationWarning,
@@ -28,7 +28,7 @@ const render_landscape_ist = async ({ model, el }) => {
 
   let meta_cell_data = { result: {}, attr: [] };
 
-  let nbhd_fc;
+  let nbhd_data;
   let nbhd_meta = { result: {}, attr: [] };
   // let umap_data;
   let meta_cluster_data = { result: {}, attr: [] };
@@ -45,7 +45,7 @@ const render_landscape_ist = async ({ model, el }) => {
 
   const nbhdBytes = model.get('nbhd_parquet');
   if (nbhdBytes && nbhdBytes.byteLength > 0) {
-    nbhd_fc = await featureCollectionFromParquet(nbhdBytes);
+    nbhd_data = await polygonDataFromParquet(nbhdBytes);
   }
 
   const metaNbhdBytes = model.get('meta_nbhd_parquet');
@@ -79,7 +79,7 @@ const render_landscape_ist = async ({ model, el }) => {
     // {}, // meta_cluster,
     meta_cluster_data.result,
     meta_cluster_data.attr,
-    nbhd_fc,
+    nbhd_data,
     nbhd_meta.result,
     nbhd_meta.attr,
     {}, // umap,


### PR DESCRIPTION
## Summary
- add helper to read polygon data with properties from a parquet file
- implement `nbhd_layer` using `SolidPolygonLayer` and Arrow data
- wire up neighborhood layer in the landscape view and tooltips
- parse neighborhood parquet in the widget

## Testing
- `npm test` *(fails: ModuleNotFoundError: No module named 'anndata')*

------
https://chatgpt.com/codex/tasks/task_b_68797cd9bdb4832a97f589b25961ee4a