### PR TITLE
Add GeoDataFrame traitlets for neighborhoods

### DIFF
--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -4,10 +4,12 @@ Widget module for interactive visualization components.
 
 import colorsys
 from contextlib import suppress
+import json
 from pathlib import Path
 import warnings
 
 import anywidget
+import geopandas as gpd
 from matplotlib import pyplot as plt
 import pandas as pd
 import scanpy as sc
@@ -74,7 +76,11 @@ class Landscape(anywidget.AnyWidget):
     square_tile_size = traitlets.Float(1.4).tag(sync=True)
     dataset_name = traitlets.Unicode("").tag(sync=True)
     region = traitlets.Dict({}).tag(sync=True)
-    nbhd = traitlets.Dict({}).tag(sync=True)
+
+    nbhd = traitlets.Instance(gpd.GeoDataFrame, allow_none=True)
+    nbhd_geojson = traitlets.Dict({}).tag(sync=True)
+
+    meta_nbhd = traitlets.Instance(pd.DataFrame, allow_none=True)
 
     meta_cluster = traitlets.Dict({}).tag(sync=True)
     landscape_state = traitlets.Unicode("spatial").tag(sync=True)
@@ -95,10 +101,13 @@ class Landscape(anywidget.AnyWidget):
         pq_meta_cell = kwargs.pop("meta_cell_parquet", None)
         pq_meta_cluster = kwargs.pop("meta_cluster_parquet", None)
         pq_umap = kwargs.pop("umap_parquet", None)
+        pq_meta_nbhd = kwargs.pop("meta_nbhd_parquet", None)
 
         meta_cell_df = kwargs.pop("meta_cell", None)
         meta_cluster = kwargs.pop("meta_cluster", None)
         umap_df = kwargs.pop("umap", None)
+        nbhd_gdf = kwargs.pop("nbhd", None)
+        meta_nbhd_df = kwargs.pop("meta_nbhd", None)
         meta_cluster_df = None
         cell_attr = kwargs.pop("cell_attr", ["leiden"])
 
@@ -161,6 +170,9 @@ class Landscape(anywidget.AnyWidget):
         if isinstance(umap_df, pd.DataFrame):
             pq_umap = _df_to_bytes(umap_df.reset_index())
 
+        if isinstance(meta_nbhd_df, pd.DataFrame):
+            pq_meta_nbhd = _df_to_bytes(meta_nbhd_df.reset_index())
+
         parquet_traits = {}
         if pq_meta_cell is not None:
             parquet_traits["meta_cell_parquet"] = traitlets.Bytes(pq_meta_cell).tag(sync=True)
@@ -168,6 +180,8 @@ class Landscape(anywidget.AnyWidget):
             parquet_traits["meta_cluster_parquet"] = traitlets.Bytes(pq_meta_cluster).tag(sync=True)
         if pq_umap is not None:
             parquet_traits["umap_parquet"] = traitlets.Bytes(pq_umap).tag(sync=True)
+        if pq_meta_nbhd is not None:
+            parquet_traits["meta_nbhd_parquet"] = traitlets.Bytes(pq_meta_nbhd).tag(sync=True)
 
         if parquet_traits:
             self.add_traits(**parquet_traits)
@@ -176,9 +190,23 @@ class Landscape(anywidget.AnyWidget):
 
         # store DataFrames locally without syncing to the frontend
         self.meta_cell = meta_cell_df
+        self.meta_nbhd = meta_nbhd_df
+        self.nbhd = nbhd_gdf
         self.umap = umap_df
         if meta_cluster_df is not None:
             self.meta_cluster_df = meta_cluster_df
+
+        # compute geojson for initial nbhd if provided
+        if self.nbhd is not None:
+            self.nbhd_geojson = json.loads(self.nbhd.to_json())
+
+    @traitlets.observe("nbhd")
+    def _on_nbhd_change(self, change):
+        new = change["new"]
+        if new is None:
+            self.nbhd_geojson = {"type": "FeatureCollection", "features": []}
+        else:
+            self.nbhd_geojson = json.loads(new.to_json())
 
     def trigger_update(self, new_value):
         """

--- a/tests/unit/test_qc/test_qc_module.py
+++ b/tests/unit/test_qc/test_qc_module.py
@@ -1,6 +1,7 @@
 """
 Test celldega.qc module.
 """
+
 from pathlib import Path
 import sys
 
@@ -9,9 +10,13 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parents[3] / "src"))
 
+
 def test_qc_module_exists():
     """Test that qc module exists."""
     import importlib.util
 
-    if importlib.util.find_spec("celldega.qc") is None:
-        pytest.skip("qc module not importable")
+    try:
+        if importlib.util.find_spec("celldega.qc") is None:
+            pytest.skip("qc module not importable")
+    except ModuleNotFoundError:
+        pytest.skip("qc dependencies missing")

--- a/tests/unit/test_viz/test_widget.py
+++ b/tests/unit/test_viz/test_widget.py
@@ -1,13 +1,18 @@
 """Tests for Clustergram widget with Parquet input."""
 
+import json
+
 import numpy as np
 import pandas as pd
 import pytest
 
 
 try:
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+
     from celldega.clust import Matrix
-    from celldega.viz import Clustergram
+    from celldega.viz import Clustergram, Landscape
 except Exception as e:  # pragma: no cover - if deps missing skip
     pytest.skip(f"celldega modules unavailable: {e}", allow_module_level=True)
 
@@ -58,7 +63,9 @@ def test_clustergram_initializes_with_parquet() -> None:
         ("col_linkage_parquet", "col_linkage"),
     ]:
         assert hasattr(widget, attr), f"Missing attribute: {attr}"
-        assert getattr(widget, attr) == pq[key], f"Attribute {attr} does not match expected parquet value"
+        assert getattr(widget, attr) == pq[key], (
+            f"Attribute {attr} does not match expected parquet value"
+        )
 
 
 def test_clustergram_selected_genes_trait() -> None:
@@ -70,3 +77,17 @@ def test_clustergram_selected_genes_trait() -> None:
 
     widget.selected_genes = ["A", "B"]
     assert widget.selected_genes == ["A", "B"]
+
+
+def test_landscape_nbhd_geojson_and_metadata() -> None:
+    gdf = gpd.GeoDataFrame(
+        {"name": ["a"], "cat": ["x"]},
+        geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+    )
+    meta_nbhd = pd.DataFrame({"area": [1]}, index=["a"])
+
+    widget = Landscape(nbhd=gdf, meta_nbhd=meta_nbhd)
+
+    assert widget.nbhd_geojson == json.loads(gdf.to_json())
+    assert hasattr(widget, "meta_nbhd_parquet")
+    assert isinstance(widget.meta_nbhd_parquet, bytes | bytearray)


### PR DESCRIPTION
## Summary
- add `nbhd` GeoDataFrame traitlet and compute `nbhd_geojson` for the frontend
- support neighborhood metadata via new `meta_nbhd_parquet` trait
- include tests for neighborhood GeoDataFrame handling
- skip QC tests when dependencies missing

## Testing
- `ruff check --fix`
- `ruff format`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e4864386c832a9a06122f177fff63