### PR TITLE
Add HTML embedding for widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ cgm = dega.viz.Clustergram(matrix=mat)
 dega.viz.landscape_clustergram(landscape_ist, cgm)
 ```
 
+### Embedding Visualizations
+
+Use the :py:meth:`embed` method on any Celldega widget to generate a
+standalone HTML snippet. This is handy on platforms like Kaggle or
+Colab that have limited widget support.
+
+```python
+landscape = dega.viz.Landscape(base_url=base_url)
+
+# Display in the notebook
+landscape.embed()
+
+# Or write to a file
+landscape.embed("landscape.html")
+```
+
 ![Celldega Demo](public/assets/celldega-demo.png)
 
 ## 📖 Documentation & Examples

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -269,6 +269,34 @@ class Landscape(anywidget.AnyWidget):
             self.send({"event": "finalize"})
         super().close()
 
+    def embed(self, fp: str | Path | None = None, **kwargs):
+        """Create an embeddable HTML snippet of the widget.
+
+        This is useful for environments like Kaggle or Colab that have
+        limited support for Jupyter widgets. If ``fp`` is provided, the
+        HTML snippet is written to that file. Otherwise an
+        :class:`IPython.display.HTML` object is returned.
+
+        Parameters
+        ----------
+        fp:
+            Optional destination file to save the HTML snippet.
+        **kwargs:
+            Additional keyword arguments forwarded to
+            :func:`ipywidgets.embed.embed_minimal_html` when ``fp`` is
+            supplied.
+        """
+
+        from IPython.display import HTML
+        from ipywidgets import embed
+
+        if fp is not None:
+            embed.embed_minimal_html(fp, [self], **kwargs)
+            return Path(fp)
+
+        html = embed.embed_snippet(self, **kwargs)
+        return HTML(html)
+
 
 class Enrich(anywidget.AnyWidget):
     """
@@ -340,6 +368,23 @@ class Enrich(anywidget.AnyWidget):
         with suppress(Exception):
             self.send({"event": "finalize"})
         super().close()
+
+    def embed(self, fp: str | Path | None = None, **kwargs):
+        """Create an embeddable HTML snippet of the widget.
+
+        Works the same as :meth:`Landscape.embed` and can be used to
+        save or display the widget outside Jupyter environments.
+        """
+
+        from IPython.display import HTML
+        from ipywidgets import embed
+
+        if fp is not None:
+            embed.embed_minimal_html(fp, [self], **kwargs)
+            return Path(fp)
+
+        html = embed.embed_snippet(self, **kwargs)
+        return HTML(html)
 
 
 class Clustergram(anywidget.AnyWidget):
@@ -425,3 +470,16 @@ class Clustergram(anywidget.AnyWidget):
         with suppress(Exception):
             self.send({"event": "finalize"})
         super().close()
+
+    def embed(self, fp: str | Path | None = None, **kwargs):
+        """Create an embeddable HTML snippet of the widget."""
+
+        from IPython.display import HTML
+        from ipywidgets import embed
+
+        if fp is not None:
+            embed.embed_minimal_html(fp, [self], **kwargs)
+            return Path(fp)
+
+        html = embed.embed_snippet(self, **kwargs)
+        return HTML(html)


### PR DESCRIPTION
## Summary
- add `embed` method to `Landscape`, `Enrich`, and `Clustergram` widgets
- document how to use the new `.embed()` helper in README

## Testing
- `pytest -k "widget" -q`

------
https://chatgpt.com/codex/tasks/task_b_6886348ac78c832a860fd8539b60c689