### PR TITLE
Auto-center landscape_sst and sync clustergram gene search

### DIFF
--- a/js/viz/landscape_sst.js
+++ b/js/viz/landscape_sst.js
@@ -44,7 +44,8 @@ export const landscape_sst = async (
 
   // Create and append the visualization container
   const root = document.createElement('div');
-  root.style.height = '800px';
+  root.style.height = `${height}px`;
+  root.style.width = typeof width === 'number' ? `${width}px` : width;
 
   const viz_state = {};
   set_options(token);
@@ -59,6 +60,30 @@ export const landscape_sst = async (
   await set_landscape_parameters(viz_state.img, base_url);
 
   await set_dimensions(viz_state, base_url, 'cells');
+
+  const parseDim = (val, ref) => {
+    if (typeof val === 'string' && val.includes('%')) {
+      const ratio = parseFloat(val) / 100;
+      return ref * ratio;
+    }
+    return parseFloat(val) || ref;
+  };
+
+  const imgWidth = viz_state.dimensions.width;
+  const imgHeight = viz_state.dimensions.height;
+  const containerWidth = parseDim(width, el.clientWidth || imgWidth);
+  const containerHeight = parseDim(height, el.clientHeight || imgHeight);
+  const scale = Math.min(
+    containerWidth / imgWidth,
+    containerHeight / imgHeight
+  );
+  const autoZoom = Math.log2(scale);
+
+  if (ini_x === 0 && ini_y === 0 && ini_zoom === 0) {
+    ini_x = imgWidth / 2;
+    ini_y = imgHeight / 2;
+    ini_zoom = autoZoom;
+  }
 
   viz_state.buttons = {};
   viz_state.buttons.blue = '#8797ff';

--- a/js/widget_interactions/update_tile_landscape_from_cgm.js
+++ b/js/widget_interactions/update_tile_landscape_from_cgm.js
@@ -16,6 +16,9 @@ export const update_tile_landscape_from_cgm = async (
     inst_gene = click_info.click_value;
     update_cat(viz_state.cats, inst_gene);
     await update_tile_exp_array(viz_state, inst_gene);
+    if (viz_state.genes && viz_state.genes.gene_search_input) {
+      viz_state.genes.gene_search_input.value = inst_gene;
+    }
   } else if (click_info.click_type === 'col-label') {
     update_cat(viz_state.cats, 'cluster');
     update_selected_cats(


### PR DESCRIPTION
## Summary
- auto-calculate initial view state in `landscape_sst`
- sync gene search input when clicking a Clustergram row

## Testing
- `npm test` *(fails: 3 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_b_688c2c7d345c832a884845c64b02f6dd