### PR TITLE
Fix SST gene info box

### DIFF
--- a/js/ui/ui_containers.js
+++ b/js/ui/ui_containers.js
@@ -281,6 +281,39 @@ export const make_sst_ui_container = (deck_sst, layers_sst, viz_state) => {
 
   set_gene_search('sst', deck_sst, layers_sst, viz_state);
 
+  // add subscriber for gene search and gene_text_box
+  viz_state.obs_store.selected_genes.subscribe(async (selected_genes) => {
+    if (selected_genes.length === 1) {
+      const inst_gene = selected_genes[0];
+
+      viz_state.genes.gene_search_input.value = inst_gene;
+
+      if (inst_gene !== '') {
+        if (viz_state.genes.gene_names.includes(inst_gene)) {
+          viz_state.genes.gene_text_box.textContent = 'loading';
+          await uniprot_get_request(inst_gene);
+          const gene_data = uniprot_data[inst_gene];
+
+          if (gene_data && gene_data.name && gene_data.description) {
+            viz_state.genes.gene_text_box.innerHTML = `<span style="color: blue;">${gene_data.name}</span><br>${gene_data.description}`;
+          } else {
+            viz_state.genes.gene_text_box.textContent = '';
+          }
+        }
+      } else {
+        viz_state.genes.gene_text_box.textContent = '';
+      }
+
+      viz_state.genes.gene_text_box.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    } else if (selected_genes.length === 0) {
+      viz_state.genes.gene_search_input.value = '';
+      viz_state.genes.gene_text_box.textContent = '';
+    }
+  });
+
   ctrl_container.appendChild(image_container);
   ctrl_container.appendChild(tile_container);
   ctrl_container.appendChild(viz_state.genes.gene_search);

--- a/js/widget_interactions/update_tile_landscape_from_cgm.js
+++ b/js/widget_interactions/update_tile_landscape_from_cgm.js
@@ -2,6 +2,7 @@
 import { update_square_scatter_layer } from '../deck-gl/layers/square_scatter_layer';
 import { update_cat, update_selected_cats } from '../global_variables/cat';
 import { update_tile_exp_array } from '../global_variables/tile_exp_array';
+import { update_selected_genes } from '../global_variables/selected_genes';
 
 export const update_tile_landscape_from_cgm = async (
   deck_sst,
@@ -31,6 +32,7 @@ export const update_tile_landscape_from_cgm = async (
     inst_gene = click_info.value.name || click_info.value;
     update_cat(viz_state.cats, inst_gene);
     await update_tile_exp_array(viz_state, inst_gene);
+    update_selected_genes(viz_state.genes, [inst_gene], viz_state.obs_store);
 
     if (viz_state.genes && viz_state.genes.gene_search_input) {
       viz_state.genes.gene_search_input.value = inst_gene;
@@ -43,6 +45,7 @@ export const update_tile_landscape_from_cgm = async (
       [click_info.value.name || click_info.value],
       viz_state.obs_store
     );
+    update_selected_genes(viz_state.genes, [], viz_state.obs_store);
   } else if (click_type === 'col_dendro') {
     update_cat(viz_state.cats, 'cluster');
     update_selected_cats(
@@ -50,8 +53,10 @@ export const update_tile_landscape_from_cgm = async (
       click_info.value.selected_names || click_info.value,
       viz_state.obs_store
     );
+    update_selected_genes(viz_state.genes, [], viz_state.obs_store);
   } else {
     update_cat(viz_state.cats, 'cluster');
+    update_selected_genes(viz_state.genes, [], viz_state.obs_store);
   }
 
   update_square_scatter_layer(viz_state, layers_sst);


### PR DESCRIPTION
## Summary
- load UniProt descriptions in the SST gene search box using obs_store
- keep the gene info in sync when clicking clustergram rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688cf655ae00832ab380492f2ed8b336