### PR TITLE
Add basic Chromium scRNA workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ mat.cluster()
 cgm = dega.viz.Clustergram(matrix=mat)
 
 dega.viz.landscape_clustergram(landscape_ist, cgm)
+
+## Chromium Example
+
+```python
+adata = sc.read_h5ad('pbmc_10x.h5ad')
+dega.pre.make_landscape_from_anndata(adata, 'pbmc_landscape')
+landscape = dega.viz.Landscape(
+    technology='Chromium',
+    base_url='pbmc_landscape',
+    AnnData=adata,
+    landscape_state='umap'
+)
+```
 ```
 
 ![Celldega Demo](public/assets/celldega-demo.png)

--- a/js/viz/landscape_chromium.js
+++ b/js/viz/landscape_chromium.js
@@ -1,0 +1,199 @@
+import { Deck, ScatterplotLayer, OrthographicView } from 'deck.gl';
+import * as d3 from 'd3';
+import { arrayBufferToArrowTable } from '../read_parquet/arrayBufferToArrowTable';
+import { options, set_options } from '../global_variables/fetch_options';
+
+const load_table = async (model, trait, url) => {
+  const bytes = model.get(trait);
+  let buffer;
+  if (bytes) {
+    buffer = bytes.buffer;
+  } else {
+    const resp = await fetch(url, options.fetch);
+    buffer = await resp.arrayBuffer();
+  }
+  return arrayBufferToArrowTable(buffer);
+};
+
+export const landscape_chromium = async (
+  model,
+  el,
+  base_url,
+  token,
+  width = 600,
+  height = 600
+) => {
+  set_options(token);
+
+  const meta_cell = await load_table(
+    model,
+    'meta_cell_parquet',
+    `${base_url}/cell_metadata.parquet`
+  );
+  const meta_cluster = await load_table(
+    model,
+    'meta_cluster_parquet',
+    `${base_url}/cell_clusters/meta_cluster.parquet`
+  );
+  const meta_gene = await load_table(
+    model,
+    'meta_gene_parquet',
+    `${base_url}/meta_gene.parquet`
+  );
+
+  const cells = [];
+  const names = meta_cell.getChild('name').toArray();
+  const geomCol = meta_cell.getChild('geometry');
+  const clusterCol = meta_cell.getChild('cluster').toArray();
+  for (let i = 0; i < meta_cell.numRows; i++) {
+    const coords = geomCol.get(i);
+    cells.push({
+      name: String(names[i]),
+      x: coords[0],
+      y: coords[1],
+      cluster: String(clusterCol[i]),
+    });
+  }
+
+  const cluster_names = meta_cluster
+    .getChild('__index_level_0__')
+    .toArray()
+    .map(String);
+  const colors = meta_cluster.getChild('color').toArray();
+  const counts = meta_cluster.getChild('count').toArray();
+
+  const color_dict = {};
+  const cluster_data = [];
+  cluster_names.forEach((name, i) => {
+    const c = d3.color(String(colors[i])) || d3.color('#808080');
+    color_dict[name] = [c.r, c.g, c.b];
+    cluster_data.push({ name, value: Number(counts[i]) });
+  });
+  cluster_data.sort((a, b) => b.value - a.value);
+
+  const gene_names = meta_gene.getChild('__index_level_0__').toArray();
+  const gene_means = meta_gene.getChild('mean').toArray();
+  const gene_data = gene_names.map((n, i) => ({
+    name: String(n),
+    value: Number(gene_means[i]),
+  }));
+  gene_data.sort((a, b) => b.value - a.value);
+
+  const xExtent = d3.extent(cells, (d) => d.x);
+  const yExtent = d3.extent(cells, (d) => d.y);
+  const centerX = (xExtent[0] + xExtent[1]) / 2;
+  const centerY = (yExtent[0] + yExtent[1]) / 2;
+  const range = Math.max(xExtent[1] - xExtent[0], yExtent[1] - yExtent[0]);
+  const iniZoom = Math.log2(Math.min(width, height) / range);
+
+  let selected_cluster = null;
+
+  const make_layer = () =>
+    new ScatterplotLayer({
+      id: 'cell-layer',
+      data: cells,
+      radiusMinPixels: 2,
+      pickable: true,
+      getPosition: (d) => [d.x, d.y],
+      getFillColor: (d) => {
+        const base = color_dict[d.cluster] || [100, 100, 100];
+        if (!selected_cluster || d.cluster === selected_cluster) {
+          return [...base, 255];
+        }
+        return [...base, 40];
+      },
+    });
+
+  const layer = make_layer();
+  const deck = new Deck({
+    parent: el,
+    width,
+    height,
+    views: [new OrthographicView({ id: 'ortho' })],
+    controller: true,
+    initialViewState: { target: [centerX, centerY, 0], zoom: iniZoom },
+    layers: [layer],
+    getTooltip: ({ object }) => (object ? object.name : null),
+  });
+
+  // -- UI containers --
+  const ui = document.createElement('div');
+  ui.style.display = 'flex';
+  ui.style.flexDirection = 'row';
+  ui.style.marginBottom = '4px';
+
+  const clusterDiv = document.createElement('div');
+  const geneDiv = document.createElement('div');
+  ui.appendChild(clusterDiv);
+  ui.appendChild(geneDiv);
+
+  const barHeight = 14;
+  const clusterScale = d3
+    .scaleLinear()
+    .domain([0, d3.max(cluster_data, (d) => d.value)])
+    .range([0, 120]);
+
+  const clusterSvg = d3
+    .create('svg')
+    .attr('width', 140)
+    .attr('height', barHeight * cluster_data.length + 10);
+  clusterDiv.appendChild(clusterSvg.node());
+
+  const clusterG = clusterSvg
+    .selectAll('g')
+    .data(cluster_data)
+    .enter()
+    .append('g')
+    .attr('transform', (_d, i) => `translate(0, ${i * barHeight})`)
+    .on('click', (_evt, d) => {
+      selected_cluster = selected_cluster === d.name ? null : d.name;
+      deck.setProps({ layers: [make_layer()] });
+    });
+
+  clusterG
+    .append('rect')
+    .attr('fill', (d) =>
+      d3.color(String(colors[cluster_names.indexOf(d.name)])).formatHex()
+    )
+    .attr('width', (d) => clusterScale(d.value))
+    .attr('height', barHeight - 2);
+  clusterG
+    .append('text')
+    .attr('x', (d) => clusterScale(d.value) + 2)
+    .attr('y', barHeight / 2)
+    .attr('dominant-baseline', 'middle')
+    .attr('font-size', '10px')
+    .text((d) => d.name);
+
+  const geneScale = d3
+    .scaleLinear()
+    .domain([0, d3.max(gene_data, (d) => d.value)])
+    .range([0, 120]);
+  const geneSvg = d3
+    .create('svg')
+    .attr('width', 140)
+    .attr('height', barHeight * gene_data.length + 10);
+  geneDiv.appendChild(geneSvg.node());
+
+  const geneG = geneSvg
+    .selectAll('g')
+    .data(gene_data)
+    .enter()
+    .append('g')
+    .attr('transform', (_d, i) => `translate(0, ${i * barHeight})`);
+
+  geneG
+    .append('rect')
+    .attr('fill', '#999')
+    .attr('width', (d) => geneScale(d.value))
+    .attr('height', barHeight - 2);
+  geneG
+    .append('text')
+    .attr('x', (d) => geneScale(d.value) + 2)
+    .attr('y', barHeight / 2)
+    .attr('dominant-baseline', 'middle')
+    .attr('font-size', '10px')
+    .text((d) => d.name);
+
+  el.appendChild(ui);
+};

--- a/js/widget.js
+++ b/js/widget.js
@@ -9,6 +9,7 @@ import {
 import { landscape_h_e } from './viz/landscape_h_e';
 import { landscape_ist } from './viz/landscape_ist';
 import { landscape_sst } from './viz/landscape_sst';
+import { landscape_chromium } from './viz/landscape_chromium';
 import { matrix_viz } from './viz/matrix_viz';
 import { render_enrich } from './widgets/enrich_widget';
 
@@ -124,6 +125,15 @@ const render_landscape_h_e = async ({ model, el }) => {
   );
 };
 
+const render_landscape_chromium = async ({ model, el }) => {
+  const token = model.get('token');
+  const base_url = model.get('base_url');
+  const width = model.get('width');
+  const height = model.get('height');
+
+  landscape_chromium(model, el, base_url, token, width, height);
+};
+
 const render_landscape = async ({ model, el }) => {
   const technology = model.get('technology');
 
@@ -133,6 +143,8 @@ const render_landscape = async ({ model, el }) => {
     return render_landscape_sst({ model, el });
   } else if (['h&e'].includes(technology)) {
     return render_landscape_h_e({ model, el });
+  } else if (['Chromium'].includes(technology)) {
+    return render_landscape_chromium({ model, el });
   }
 };
 
@@ -228,6 +240,7 @@ export default {
   render_landscape_ist,
   render_landscape_sst,
   render_landscape_h_e,
+  render_landscape_chromium,
   render_landscape,
   render_matrix_new,
   render_enrich,

--- a/src/celldega/pre/__init__.py
+++ b/src/celldega/pre/__init__.py
@@ -18,6 +18,8 @@ import xml.etree.ElementTree as ET
 from matplotlib.colors import to_hex
 import matplotlib.pyplot as plt
 import pandas as pd
+
+from .chromium import make_landscape_from_anndata
 from scipy.sparse import csr_matrix
 from shapely.geometry import MultiPolygon, Point, Polygon
 from skimage.io import imread, imsave
@@ -1232,4 +1234,5 @@ __all__ = [
     "make_trx_tiles",
     "read_cbg_mtx",
     "trx_tile",
+    "make_landscape_from_anndata",
 ]

--- a/src/celldega/pre/chromium.py
+++ b/src/celldega/pre/chromium.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+import numpy as np
+import scipy.sparse as sp
+from anndata import AnnData
+
+from .landscape import calc_meta_gene_data, save_cbg_gene_parquets
+from . import _create_cluster_colors
+
+
+def make_landscape_from_anndata(
+    adata: AnnData,
+    path_landscape_files: str | Path,
+    *,
+    use_int_index: bool = False,
+) -> None:
+    """Generate landscape files from an AnnData object.
+
+    Parameters
+    ----------
+    adata : AnnData
+        Input AnnData with ``X_umap`` coordinates and optional ``leiden``
+        clustering in ``.obs``.
+    path_landscape_files : str or Path
+        Output directory for landscape files.
+    use_int_index : bool, optional
+        Whether to convert cell names to integer indices when saving gene
+        matrices. Defaults to ``False``.
+    """
+    path = Path(path_landscape_files)
+    path.mkdir(parents=True, exist_ok=True)
+
+    if "X_umap" not in adata.obsm:
+        raise ValueError("AnnData must contain 'X_umap' coordinates")
+
+    # --- meta cell ---
+    cells = adata.obs_names.astype(str)
+    umap = adata.obsm["X_umap"]
+    meta_cell = pd.DataFrame({"name": cells, "geometry": umap.tolist()})
+
+    if "leiden" in adata.obs:
+        meta_cell["cluster"] = adata.obs["leiden"].astype(str).values
+    else:
+        meta_cell["cluster"] = "0"
+
+    meta_cell.to_parquet(path / "cell_metadata.parquet", index=False)
+
+    # --- cell clusters ---
+    counts = meta_cell["cluster"].value_counts().sort_index()
+    clusters = counts.index.tolist()
+    colors = adata.uns.get("leiden_colors")
+    if colors is None:
+        colors = _create_cluster_colors(clusters)
+
+    cell_clusters_dir = path / "cell_clusters"
+    cell_clusters_dir.mkdir(exist_ok=True)
+    meta_cell[["name", "cluster"]].rename(columns={"cluster": "cluster"}).set_index("name").to_parquet(
+        cell_clusters_dir / "cluster.parquet"
+    )
+    meta_cluster = pd.DataFrame({"color": colors[: len(clusters)], "count": counts.values}, index=clusters)
+    meta_cluster.to_parquet(cell_clusters_dir / "meta_cluster.parquet")
+
+    # --- cell by gene matrix ---
+    if sp.issparse(adata.X):
+        cbg = pd.DataFrame.sparse.from_spmatrix(adata.X, index=cells, columns=adata.var_names.astype(str))
+    else:
+        cbg = pd.DataFrame(adata.X, index=cells, columns=adata.var_names.astype(str))
+
+    meta_gene = calc_meta_gene_data(cbg)
+    meta_gene.to_parquet(path / "meta_gene.parquet")
+
+    save_cbg_gene_parquets(path, cbg, verbose=False)
+
+    # cluster gene expression
+    df_sig = cbg.groupby(meta_cell["cluster"]).mean().T
+    df_sig.to_parquet(path / "df_sig.parquet")
+
+    # --- landscape parameters ---
+    params = {
+        "technology": "Chromium",
+        "segmentation_approach": ["default"],
+        "max_pyramid_zoom": None,
+        "tile_size": None,
+        "image_info": [],
+        "image_format": "",
+        "use_int_index": use_int_index,
+    }
+    with open(path / "landscape_parameters.json", "w") as fh:
+        json.dump(params, fh, indent=4)
+

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -147,6 +147,7 @@ class Landscape(anywidget.AnyWidget):
                 adata.obs.set_index("cell_id", inplace=True)
 
             meta_cell_df = adata.obs[cell_attr].copy()
+            meta_cell_df["cell_id"] = meta_cell_df.index.astype(str)
             pq_meta_cell = _df_to_bytes(meta_cell_df)
 
             if "leiden" in adata.obs.columns:


### PR DESCRIPTION
## Summary
- add `make_landscape_from_anndata` for 10X Chromium data
- expose it from `celldega.pre`
- include cell_id column in AnnData metadata processing
- support `Chromium` tech in widget and add minimal renderer
- document usage for Chromium datasets
- use deck.gl renderer for Chromium

## Testing
- `pytest tests/unit/test_viz/test_landscape_colors.py::test_leiden_colors_added_if_missing -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_688cdd9afd80832aa0e185df40ce4f73