### PR TITLE
Move UMAP state into observable store and refine spatial transitions

### DIFF
--- a/js/deck-gl/core/on_view_state_change.js
+++ b/js/deck-gl/core/on_view_state_change.js
@@ -6,7 +6,7 @@ const bounce_time = 200;
 
 export const on_view_state_change = debounce(
   ({ viewState }, deck_ist, layers_obj, viz_state) => {
-    if (viz_state.umap.state === false) {
+    if (viz_state.obs_store.umap_state.get() === false) {
       calc_viewport(viewState, deck_ist, layers_obj, viz_state);
     }
 

--- a/js/deck-gl/layers/cell_layer.js
+++ b/js/deck-gl/layers/cell_layer.js
@@ -248,9 +248,10 @@ export const ini_cell_layer = async (base_url, viz_state) => {
     getFillColor: (i, d) => get_cell_color(viz_state.cats, i, d),
     data: viz_state.spatial.cell_scatter_data_objects,
     transitions,
-    getPosition: (d) => (viz_state.umap.state ? d.umap : d.position),
+    getPosition: (d) =>
+      viz_state.obs_store.umap_state.get() ? d.umap : d.position,
     updateTriggers: {
-      getPosition: [viz_state.umap.state],
+      getPosition: [viz_state.obs_store.umap_state.get()],
     },
   });
 
@@ -282,10 +283,10 @@ export const update_cell_pickable_state = (layers_obj, pickable) => {
   });
 };
 
-export const toggle_spatial_umap = (deck_ist, layers_obj, viz_state) => {
+export const toggle_spatial_umap = (_deck_ist, layers_obj, viz_state) => {
   layers_obj.cell_layer = layers_obj.cell_layer.clone({
     updateTriggers: {
-      getPosition: [viz_state.umap.state],
+      getPosition: [viz_state.obs_store.umap_state.get()],
     },
   });
 };

--- a/js/obs_store/obs_store.js
+++ b/js/obs_store/obs_store.js
@@ -33,6 +33,7 @@ export const create_obs_store = () => {
     viz_background_layer: Observable(true),
     viz_nbhd_layer: Observable(false),
     landscape_view: Observable('spatial'),
+    umap_state: Observable(false),
     // to do utilize for setProps
     deck_check: Observable({
       background_layer: true,

--- a/js/ui/text_buttons.js
+++ b/js/ui/text_buttons.js
@@ -177,15 +177,21 @@ const sst_img_button_callback = async (event, deck_sst, layers_sst) => {
 
 const ist_img_button_callback = async (
   event,
-  deck_ist,
-  layers_obj,
+  _deck_ist,
+  _layers_obj,
   viz_state
 ) => {
   toggle_visible_button(event);
-  viz_state.obs_store.viz_image_layers.set(is_visible);
-  viz_state.obs_store.viz_background_layer.set(is_visible);
+  const show = is_visible;
 
-  set_img_layer_visible(is_visible);
+  if (viz_state.obs_store.umap_state.get() && show) {
+    viz_state.obs_store.landscape_view.set('spatial');
+  } else {
+    viz_state.obs_store.viz_image_layers.set(show);
+    viz_state.obs_store.viz_background_layer.set(show);
+  }
+
+  set_img_layer_visible(show);
 };
 
 const tile_button_callback = async (event, deck_sst, layers_sst, viz_state) => {

--- a/js/ui/ui_containers.js
+++ b/js/ui/ui_containers.js
@@ -51,9 +51,7 @@ import {
   // make_edit_button,
   make_reorder_button,
 } from './text_buttons';
-import {
-  toggle_spatial_umap,
-} from '../deck-gl/layers/cell_layer';
+
 
 export const make_ui_container = () => {
   const ui_container = document.createElement('div');
@@ -388,10 +386,11 @@ export const make_ist_ui_container = (
   );
 
   if (viz_state.umap.has_umap === true) {
+    const umap_active = viz_state.obs_store.umap_state.get();
     let ini_umap_color;
     let ini_spatial_color;
 
-    if (viz_state.umap.state === true) {
+    if (umap_active === true) {
       ini_umap_color = 'blue';
       ini_spatial_color = 'gray';
     } else {
@@ -508,10 +507,8 @@ export const make_ist_ui_container = (
     refresh_layer(viz_state, layers_obj, 'image_layers');
 
     // move out of umap state if image is visible
-    if (viz_image_layers) {
-      viz_state.umap.state = false;
-      // viz_state.obs_store.umap_state.set(false);
-      toggle_spatial_umap(deck_ist, layers_obj, viz_state);
+    if (viz_image_layers && viz_state.obs_store.umap_state.get()) {
+      viz_state.obs_store.landscape_view.set('spatial');
     }
 
   });

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -243,12 +243,8 @@ export const landscape_ist = async (
   }
   viz_state.umap.umap = umap;
 
-  if (landscape_state === 'spatial') {
-    viz_state.umap.state = false;
-  } else if (landscape_state === 'umap') {
-    viz_state.umap.state = true;
-  }
-
+  const isUmapInit = landscape_state === 'umap';
+  viz_state.obs_store.umap_state.set(isUmapInit);
   viz_state.obs_store.landscape_view.set(landscape_state);
 
   viz_state.genes = {};
@@ -470,7 +466,7 @@ export const landscape_ist = async (
 
   update_trx_layer_radius(layers_obj, trx_radius);
 
-  if (viz_state.umap.state === true) {
+  if (viz_state.obs_store.umap_state.get() === true) {
     viz_state.obs_store.viz_background_layer.set(false);
     viz_state.obs_store.viz_image_layers.set(false);
     toggle_trx_layer_visibility(layers_obj, false);
@@ -506,7 +502,7 @@ export const landscape_ist = async (
     console.log(`Landscape view changed to: ${view}`);
 
     const isUmap = view === 'umap';
-    viz_state.umap.state = isUmap;
+    viz_state.obs_store.umap_state.set(isUmap);
 
     toggle_spatial_umap(deck_ist, layers_obj, viz_state);
 
@@ -543,25 +539,26 @@ export const landscape_ist = async (
       viz_state.buttons.buttons.spatial.style('color', 'blue');
       viz_state.buttons.buttons.img.style('color', 'blue');
 
-      console.log('delay transition to spatial');
+      toggle_trx_layer_visibility(layers_obj, true);
+      toggle_path_layer_visibility(layers_obj, true);
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: false,
+        path_layer: false,
+        trx_layer: false,
+      });
+      viz_state.layers_obj = layers_obj;
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: true,
+        path_layer: true,
+        trx_layer: true,
+      });
+
       setTimeout(() => {
         viz_state.obs_store.viz_background_layer.set(true);
         viz_state.obs_store.viz_image_layers.set(true);
-        toggle_trx_layer_visibility(layers_obj, true);
-        toggle_path_layer_visibility(layers_obj, true);
-        viz_state.obs_store.deck_check.set({
-          ...viz_state.obs_store.deck_check.get(),
-          cell_layer: false,
-          path_layer: false,
-          trx_layer: false,
-        });
-        viz_state.layers_obj = layers_obj;
-        viz_state.obs_store.deck_check.set({
-          ...viz_state.obs_store.deck_check.get(),
-          cell_layer: true,
-          path_layer: true,
-          trx_layer: true,
-        });
       }, 3000);
     }
   }, { immediate: false });

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -105,7 +105,10 @@ export const landscape_ist = async (
     if (hasCats || hasGenes) {
       viz_state.obs_store.viz_image_layers.set(false);
     } else {
-      viz_state.obs_store.viz_image_layers.set(true);
+      // only do this if not in umap view
+      if (viz_state.obs_store.umap_state.get() === false) {
+        viz_state.obs_store.viz_image_layers.set(true);
+      }
     }
   };
 
@@ -435,6 +438,7 @@ export const landscape_ist = async (
   });
 
   viz_state.obs_store.selected_cats.subscribe((selected_cats) => {
+
     const selected_cats_name = selected_cats.join('-');
 
     layers_obj.cell_layer = layers_obj.cell_layer.clone({
@@ -498,8 +502,6 @@ export const landscape_ist = async (
   el.appendChild(root);
 
   viz_state.obs_store.landscape_view.subscribe((view) => {
-
-    console.log(`Landscape view changed to: ${view}`);
 
     const isUmap = view === 'umap';
     viz_state.obs_store.umap_state.set(isUmap);

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -473,6 +473,9 @@ export const landscape_ist = async (
   if (viz_state.obs_store.umap_state.get() === true) {
     viz_state.obs_store.viz_background_layer.set(false);
     viz_state.obs_store.viz_image_layers.set(false);
+
+
+
     toggle_trx_layer_visibility(layers_obj, false);
     toggle_path_layer_visibility(layers_obj, false);
   }


### PR DESCRIPTION
## Summary
- track UMAP mode with a new `umap_state` observable in the shared store
- update cell layer, view handling, and UI to read from the observable and exit UMAP when images are shown
- delay only image/background layer visibility when switching from UMAP to spatial

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_b_6892d51bf7a4832a8dddd77e97805f9d