### PR TITLE
Switch image channel buttons from UMAP to spatial

### DIFF
--- a/js/ui/text_buttons.js
+++ b/js/ui/text_buttons.js
@@ -328,29 +328,39 @@ const make_ist_img_layer_button_callback = (
   viz_state
 ) => {
   return async (event) => {
-    if (img_layer_visible) {
-      toggle_visible_button(event);
+    const inUmap = viz_state.obs_store.umap_state.get();
 
-      toggle_visibility_single_image_layer(layers_obj, text, is_visible);
-
-      const inst_slider = viz_state.img.image_layer_sliders.filter(
-        (slider) => slider.name === text
-      )[0];
-
-      toggle_slider(inst_slider, is_visible);
-
-      viz_state.obs_store.deck_check.set({
-        ...viz_state.obs_store.deck_check.get(),
-        image_layers: false,
-      });
-
-      viz_state.layers_obj = layers_obj;
-
-      viz_state.obs_store.deck_check.set({
-        ...viz_state.obs_store.deck_check.get(),
-        image_layers: true,
-      });
+    if (!img_layer_visible && !inUmap) {
+      return;
     }
+
+    toggle_visible_button(event);
+
+    if (inUmap) {
+      viz_state.obs_store.landscape_view.set('spatial');
+      viz_state.obs_store.viz_background_layer.set(true);
+      viz_state.obs_store.viz_image_layers.set(true);
+    }
+
+    toggle_visibility_single_image_layer(layers_obj, text, is_visible);
+
+    const inst_slider = viz_state.img.image_layer_sliders.filter(
+      (slider) => slider.name === text
+    )[0];
+
+    toggle_slider(inst_slider, is_visible);
+
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      image_layers: false,
+    });
+
+    viz_state.layers_obj = layers_obj;
+
+    viz_state.obs_store.deck_check.set({
+      ...viz_state.obs_store.deck_check.get(),
+      image_layers: true,
+    });
   };
 };
 

--- a/js/ui/ui_containers.js
+++ b/js/ui/ui_containers.js
@@ -446,11 +446,15 @@ export const make_ist_ui_container = (
     const inst_container = flex_container('image_layer_container', 'row');
     inst_container.style.height = '21px';
 
+    const ini_img_color = viz_state.obs_store.umap_state.get()
+      ? 'gray'
+      : 'blue';
+
     make_button(
       inst_container,
       'ist',
       inst_name,
-      'blue',
+      ini_img_color,
       75,
       'img_layer_button',
       deck_ist,


### PR DESCRIPTION
## Summary
- Initialize image channel buttons in gray when the view starts in UMAP
- Clicking an image channel while in UMAP now swaps the view to spatial and enables image layers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6892dea92538832abe03dae17eecaf0e