### PR TITLE
Fix cell layer lag when selecting genes

### DIFF
--- a/js/deck-gl/layers/trx_layer.js
+++ b/js/deck-gl/layers/trx_layer.js
@@ -1,7 +1,6 @@
 import { ScatterplotLayer } from 'deck.gl';
 
 import { update_cat, update_selected_cats } from '../../global_variables/cat';
-import { update_cell_exp_array } from '../../global_variables/cell_exp_array';
 import { update_selected_genes } from '../../global_variables/selected_genes';
 import { grab_trx_tiles_in_view } from '../../vector_tile/transcripts/grab_trx_tiles_in_view';
 
@@ -34,16 +33,6 @@ const trx_layer_callback = async (
   // testing setting selected_cats to array with the selected gene for
   // observable updates
   update_selected_cats(viz_state.cats, [inst_gene], viz_state.obs_store);
-
-  await update_cell_exp_array(
-    viz_state.cats,
-    viz_state.genes,
-    viz_state.global_base_url,
-    inst_gene,
-    viz_state.seg.version,
-    viz_state.vector_name_integer,
-    viz_state.aws
-  );
 };
 
 export const ini_trx_layer = (genes) => {

--- a/js/ui/bar_plot.js
+++ b/js/ui/bar_plot.js
@@ -3,7 +3,6 @@ import * as d3 from 'd3';
 import { new_toggle_cell_layer_visibility } from '../deck-gl/layers/cell_layer';
 import { toggle_trx_layer_visibility } from '../deck-gl/layers/trx_layer';
 import { update_cat, update_selected_cats } from '../global_variables/cat';
-import { update_cell_exp_array } from '../global_variables/cell_exp_array';
 import { update_selected_genes } from '../global_variables/selected_genes';
 import { toggle_slider } from '../ui/sliders';
 import { refresh_layer } from '../utils/refresh_layer';
@@ -92,15 +91,6 @@ export const bar_callback_gene = async (
   // testing setting selected_cats to array with the selected gene for
   // observable updates
   update_selected_cats(_viz_state.cats, [inst_gene], _viz_state.obs_store);
-  await update_cell_exp_array(
-    _viz_state.cats,
-    _viz_state.genes,
-    _viz_state.global_base_url,
-    inst_gene,
-    _viz_state.seg.version,
-    _viz_state.vector_name_integer,
-    _viz_state.aws
-  );
 };
 
 export const bar_callback_nbhd = (

--- a/js/ui/gene_search.js
+++ b/js/ui/gene_search.js
@@ -1,6 +1,5 @@
 import { update_square_scatter_layer } from '../deck-gl/layers/square_scatter_layer';
 import { update_cat, update_selected_cats } from '../global_variables/cat';
-import { update_cell_exp_array } from '../global_variables/cell_exp_array';
 import { update_selected_genes } from '../global_variables/selected_genes';
 import { update_tile_exp_array } from '../global_variables/tile_exp_array';
 
@@ -72,15 +71,7 @@ const ist_gene_search_callback = async (deck_ist, layers_obj, viz_state) => {
       viz_state.genes.gene_names.includes(inst_gene);
 
     if (inst_gene_in_gene_names) {
-      await update_cell_exp_array(
-        viz_state.cats,
-        viz_state.genes,
-        viz_state.global_base_url,
-        inst_gene,
-        viz_state.seg.version,
-        viz_state.vector_name_integer,
-        viz_state.aws
-      );
+      // cell by gene data will be handled by selected_genes subscriber
     }
   }
 };

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -456,16 +456,56 @@ export const landscape_ist = async (
     });
   });
 
-  viz_state.obs_store.selected_genes.subscribe((selected_genes) => {
+  let gene_request = 0;
+  viz_state.obs_store.selected_genes.subscribe(async (selected_genes) => {
+    const request_id = ++gene_request;
     const selected_genes_name = selected_genes.join('-');
     layers_obj.trx_layer = layers_obj.trx_layer.clone({
       id: `trx-layer-${selected_genes_name}`,
     });
 
-    viz_state.obs_store.deck_check.set({
-      ...viz_state.obs_store.deck_check.get(),
-      trx_layer: true,
-    });
+    if (selected_genes.length === 1) {
+      const inst_gene = selected_genes[0];
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: false,
+        trx_layer: false,
+      });
+
+      await update_cell_exp_array(
+        viz_state.cats,
+        viz_state.genes,
+        viz_state.global_base_url,
+        inst_gene,
+        viz_state.seg.version,
+        viz_state.vector_name_integer,
+        viz_state.aws
+      );
+
+      if (request_id === gene_request) {
+        layers_obj.cell_layer = layers_obj.cell_layer.clone({
+          id: `cell-layer-${selected_genes_name}`,
+        });
+
+        viz_state.obs_store.deck_check.set({
+          ...viz_state.obs_store.deck_check.get(),
+          cell_layer: true,
+          trx_layer: true,
+        });
+      }
+    } else {
+      viz_state.cats.cell_exp_array = [];
+      layers_obj.cell_layer = layers_obj.cell_layer.clone({
+        id: `cell-layer-${selected_genes_name}`,
+      });
+
+      viz_state.obs_store.deck_check.set({
+        ...viz_state.obs_store.deck_check.get(),
+        cell_layer: true,
+        trx_layer: true,
+      });
+    }
   });
 
   update_trx_layer_radius(layers_obj, trx_radius);
@@ -581,22 +621,8 @@ export const landscape_ist = async (
         new_cat === 'cluster' ? [] : [inst_gene],
         viz_state.obs_store
       );
-      await update_cell_exp_array(
-        viz_state.cats,
-        viz_state.genes,
-        viz_state.global_base_url,
-        inst_gene,
-        viz_state.seg.version,
-        viz_state.vector_name_integer,
-        viz_state.aws
-      );
 
       viz_state.layers_obj = layers_obj;
-
-      viz_state.obs_store.deck_check.set({
-        ...viz_state.obs_store.deck_check.get(),
-        cell_layer: true,
-      });
     },
     update_matrix_col: async (inst_col) => {
       update_cat(viz_state.cats, 'cluster');

--- a/js/widget_interactions/update_ist_landscape_from_cgm.js
+++ b/js/widget_interactions/update_ist_landscape_from_cgm.js
@@ -1,8 +1,6 @@
 import { update_cat, update_selected_cats } from '../global_variables/cat';
-import { update_cell_exp_array } from '../global_variables/cell_exp_array';
 import { update_selected_genes } from '../global_variables/selected_genes';
 import { handleAsyncError } from '../temp_utils/errorHandler';
-import { refresh_layer } from '../utils/refresh_layer';
 
 export const update_ist_landscape_from_cgm = async (
   deck_ist,
@@ -44,17 +42,7 @@ export const update_ist_landscape_from_cgm = async (
         viz_state.obs_store
       );
 
-      await update_cell_exp_array(
-        viz_state.cats,
-        viz_state.genes,
-        viz_state.global_base_url,
-        inst_gene,
-        viz_state.seg.version,
-        viz_state.vector_name_integer,
-        viz_state.aws
-      );
-
-      refresh_layer(viz_state, layers_obj, 'cell_layer');
+      // cell by gene data and cell layer refresh handled by selected_genes subscriber
     } else if (click_type === 'col_label') {
       inst_gene = 'cluster';
       new_cat = click_info.value.name;
@@ -63,7 +51,7 @@ export const update_ist_landscape_from_cgm = async (
       update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
       update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      refresh_layer(viz_state, layers_obj, 'cell_layer');
+      // cell layer refresh handled by selected_genes subscriber
     } else if (click_type === 'col_dendro') {
       const new_cats = click_info.value.selected_names;
 
@@ -71,7 +59,7 @@ export const update_ist_landscape_from_cgm = async (
       update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
       update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      refresh_layer(viz_state, layers_obj, 'cell_layer');
+      // cell layer refresh handled by selected_genes subscriber
     }
   } catch (error) {
     handleAsyncError(error, {


### PR DESCRIPTION
## Summary
- load cell-by-gene data and recolor cells whenever `selected_genes` changes
- rely on observable to refresh cell layer; remove per-component expression fetches

## Testing
- `npm test`
- `npm run test:py`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_b_68936af823b4832a9c832bfd66281fa4