### PR TITLE
feat: add entity option for clustergram-landscape sync

### DIFF
--- a/js/widget_interactions/update_ist_landscape_from_cgm.js
+++ b/js/widget_interactions/update_ist_landscape_from_cgm.js
@@ -14,6 +14,8 @@ export const update_ist_landscape_from_cgm = async (
     return;
   }
 
+  const entity = viz_state.model.get('interaction_entity') || 'cell';
+
   const click_info = {
     type: raw_click.type || raw_click.click_type,
     value: raw_click.value || raw_click.click_value,
@@ -30,50 +32,83 @@ export const update_ist_landscape_from_cgm = async (
 
   // add try catch block
   try {
-    if (click_type === 'row_label') {
+    if (entity === 'nbhd') {
+      if (click_type === 'row_label') {
+        inst_gene = click_info.value.name;
 
-      inst_gene = click_info.value.name;
+        new_cat = inst_gene === viz_state.cats.cat ? 'cluster' : inst_gene;
 
-      new_cat = inst_gene === viz_state.cats.cat ? 'cluster' : inst_gene;
+        update_cat(viz_state.cats, new_cat);
+        update_selected_genes(viz_state.genes, [inst_gene], viz_state.obs_store);
+        update_selected_cats(
+          viz_state.cats,
+          new_cat === 'cluster' ? [] : [inst_gene],
+          viz_state.obs_store
+        );
 
-      update_cat(viz_state.cats, new_cat);
-      update_selected_genes(viz_state.genes, [inst_gene], viz_state.obs_store);
-      // update_selected_cats(viz_state.cats, [], viz_state.obs_store);
-      update_selected_cats(
-        viz_state.cats,
-        new_cat === 'cluster' ? [] : [inst_gene],
-        viz_state.obs_store
-      );
+        refresh_layer(viz_state, layers_obj, 'nbhd_layer');
+      } else if (click_type === 'col_label') {
+        inst_gene = 'cluster';
+        new_cat = click_info.value.name;
 
-      await update_cell_exp_array(
-        viz_state.cats,
-        viz_state.genes,
-        viz_state.global_base_url,
-        inst_gene,
-        viz_state.seg.version,
-        viz_state.vector_name_integer,
-        viz_state.aws
-      );
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      refresh_layer(viz_state, layers_obj, 'cell_layer');
-    } else if (click_type === 'col_label') {
+        refresh_layer(viz_state, layers_obj, 'nbhd_layer');
+      } else if (click_type === 'col_dendro') {
+        const new_cats = click_info.value.selected_names;
 
-      inst_gene = 'cluster';
-      new_cat = click_info.value.name;
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      update_cat(viz_state.cats, 'cluster');
-      update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
-      update_selected_genes(viz_state.genes, [], viz_state.obs_store);
+        refresh_layer(viz_state, layers_obj, 'nbhd_layer');
+      }
+    } else if (entity === 'cell') {
+      if (click_type === 'row_label') {
+        inst_gene = click_info.value.name;
 
-      refresh_layer(viz_state, layers_obj, 'cell_layer');
-    } else if (click_type === 'col_dendro') {
-      const new_cats = click_info.value.selected_names;
+        new_cat = inst_gene === viz_state.cats.cat ? 'cluster' : inst_gene;
 
-      update_cat(viz_state.cats, 'cluster');
-      update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
-      update_selected_genes(viz_state.genes, [], viz_state.obs_store);
+        update_cat(viz_state.cats, new_cat);
+        update_selected_genes(viz_state.genes, [inst_gene], viz_state.obs_store);
+        // update_selected_cats(viz_state.cats, [], viz_state.obs_store);
+        update_selected_cats(
+          viz_state.cats,
+          new_cat === 'cluster' ? [] : [inst_gene],
+          viz_state.obs_store
+        );
 
-      refresh_layer(viz_state, layers_obj, 'cell_layer');
+        await update_cell_exp_array(
+          viz_state.cats,
+          viz_state.genes,
+          viz_state.global_base_url,
+          inst_gene,
+          viz_state.seg.version,
+          viz_state.vector_name_integer,
+          viz_state.aws
+        );
+
+        refresh_layer(viz_state, layers_obj, 'cell_layer');
+      } else if (click_type === 'col_label') {
+        inst_gene = 'cluster';
+        new_cat = click_info.value.name;
+
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
+
+        refresh_layer(viz_state, layers_obj, 'cell_layer');
+      } else if (click_type === 'col_dendro') {
+        const new_cats = click_info.value.selected_names;
+
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
+
+        refresh_layer(viz_state, layers_obj, 'cell_layer');
+      }
     }
   } catch (error) {
     handleAsyncError(error, {

--- a/src/celldega/viz/__init__.py
+++ b/src/celldega/viz/__init__.py
@@ -8,7 +8,13 @@ from .local_server import get_local_server
 from .widget import Clustergram, Enrich, Landscape
 
 
-def landscape_clustergram(landscape, mat, width="600px", height="700px"):
+def landscape_clustergram(
+    landscape,
+    mat,
+    width="600px",
+    height="700px",
+    entity: str = "cell",
+):
     """
     Display a `Landscape` widget and a `Clustergram` widget side by side.
 
@@ -17,6 +23,9 @@ def landscape_clustergram(landscape, mat, width="600px", height="700px"):
         cgm (Clustergram): A `Clustergram` widget.
         width (str): The width of the widgets.
         height (str): The height of the widgets.
+        entity (str): The landscape layer to sync with the Clustergram. Use
+            ``"cell"`` for the cell layer or ``"nbhd"`` for the neighborhood
+            layer.
 
     Returns:
         HBox: Visualization display containing both widgets
@@ -26,6 +35,7 @@ def landscape_clustergram(landscape, mat, width="600px", height="700px"):
     """
     # Use `jslink` to directly link `click_info` from `mat` to `trigger_value` in `landscape_ist`
     jslink((mat, "click_info"), (landscape, "update_trigger"))
+    landscape.interaction_entity = entity
 
     # Set layouts for the widgets
     mat.layout = Layout(width=width)  # Adjust as needed

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -99,6 +99,7 @@ class Landscape(anywidget.AnyWidget):
 
     width = traitlets.Int(0).tag(sync=True)
     height = traitlets.Int(800).tag(sync=True)
+    interaction_entity = traitlets.Unicode("cell").tag(sync=True)
 
     def __init__(self, **kwargs):
         adata = kwargs.pop("adata", None) or kwargs.pop("AnnData", None)


### PR DESCRIPTION
## Summary
- allow landscape-clustergram links to target nbhd or cell layers
- add `interaction_entity` trait to Landscape widget
- handle nbhd layer updates in clustergram interactions

## Testing
- `npm test` *(fails: module 'celldega.nbhd.hextile' has no attribute 'cluster_hex_tiles_leiden')*
- `npm run lint:js`
- `npm run lint:py`


------
https://chatgpt.com/codex/tasks/task_b_6893781f9d208326916563f988ca93bd