### PR TITLE
feat: add entity support to widgets

### DIFF
--- a/js/deck-gl/matrix/dendro_layers.js
+++ b/js/deck-gl/matrix/dendro_layers.js
@@ -48,6 +48,7 @@ const dendro_layer_onclick = (event, deck_mat, layers_mat, viz_state, axis) => {
   viz_state.click.value = {
     name: event.object.properties.name,
     selected_names: event.object.properties.all_names,
+    entity: viz_state.entity[axis],
   };
 
   if (Object.keys(viz_state.model).length > 0) {

--- a/js/deck-gl/matrix/label_layers.js
+++ b/js/deck-gl/matrix/label_layers.js
@@ -213,6 +213,7 @@ const row_label_layer_onclick = (event, deck_mat, layers_mat, viz_state) => {
     viz_state.click.type = 'row_label';
     viz_state.click.value = {
       name: event.object.name,
+      entity: viz_state.entity.row,
     };
 
     setTimeout(() => {
@@ -249,6 +250,7 @@ const col_label_layer_onclick = (event, deck_mat, layers_mat, viz_state) => {
     viz_state.click.type = 'col_label';
     viz_state.click.value = {
       name: event.object.name,
+      entity: viz_state.entity.col,
     };
 
     setTimeout(() => {

--- a/js/deck-gl/matrix/mat_layer.js
+++ b/js/deck-gl/matrix/mat_layer.js
@@ -51,6 +51,8 @@ const mat_layer_onclick = (event, deck_mat, layers_mat, viz_state) => {
     name: `${row_name}_${col_name}`,
     row: row_name,
     col: col_name,
+    row_entity: viz_state.entity.row,
+    col_entity: viz_state.entity.col,
   };
 
   if (Object.keys(viz_state.model).length > 0) {

--- a/js/matrix/set_constants.js
+++ b/js/matrix/set_constants.js
@@ -6,6 +6,7 @@ export const set_mat_constants = (
   root,
   width,
   height,
+  entity,
   row_label_callback,
   col_label_callback,
   col_dendro_callback
@@ -96,6 +97,15 @@ export const set_mat_constants = (
   viz_state.animate.duration = 2500;
 
   viz_state.viz.dendrogram_width = 15;
+
+  viz_state.entity = {};
+  if (entity === 'NBHD') {
+    viz_state.entity.row = 'cell';
+    viz_state.entity.col = 'nbhd';
+  } else {
+    viz_state.entity.row = 'gene';
+    viz_state.entity.col = 'cell';
+  }
 
   //////////////////////////////
   // Variables

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -81,6 +81,7 @@ export const landscape_ist = async (
   meta_cluster_attr = [],
   umap = {},
   nbhd = {},
+  entity = 'CELL',
   landscape_state = 'spatial',
   segmentation = 'default',
   creds = {},
@@ -118,6 +119,8 @@ export const landscape_ist = async (
 
   viz_state.seg = {};
   viz_state.seg.version = segmentation;
+
+  viz_state.entity = entity;
 
   viz_state.root = el;
   viz_state.buttons = {};

--- a/js/viz/matrix_viz.js
+++ b/js/viz/matrix_viz.js
@@ -65,6 +65,7 @@ export const matrix_viz = async (
   network,
   width = '800',
   height = '800',
+  entity = 'CELL',
   row_label_callback = null,
   col_label_callback = null,
   col_dendro_callback = null
@@ -80,6 +81,7 @@ export const matrix_viz = async (
     root,
     width,
     height,
+    entity,
     row_label_callback,
     col_label_callback,
     col_dendro_callback

--- a/js/widget.js
+++ b/js/widget.js
@@ -24,6 +24,7 @@ const render_landscape_ist = async ({ model, el }) => {
   const dataset_name = model.get('dataset_name');
   const width = model.get('width');
   const height = model.get('height');
+  const entity = model.get('entity');
 
   const nbhd = model.get('nbhd_geojson');
 
@@ -72,6 +73,7 @@ const render_landscape_ist = async ({ model, el }) => {
     meta_cluster_data.attr,
     umap_data,
     nbhd,
+    entity,
     landscape_state,
     segmentation,
     creds
@@ -151,6 +153,7 @@ const render_matrix_new = async ({ model, el }) => {
   let network;
   const width = model.get('width');
   const height = model.get('height');
+  const entity = model.get('entity');
 
   const matBytes = model.get('mat_parquet');
   if (matBytes && matBytes.byteLength > 0) {
@@ -164,7 +167,7 @@ const render_matrix_new = async ({ model, el }) => {
     );
   }
 
-  return matrix_viz(model, el, network, width, height);
+  return matrix_viz(model, el, network, width, height, entity);
 };
 
 // Main render function - no export keyword

--- a/js/widget_interactions/update_ist_landscape_from_cgm.js
+++ b/js/widget_interactions/update_ist_landscape_from_cgm.js
@@ -1,4 +1,3 @@
-import { update_nbhd_layer_data } from '../deck-gl/layers/nbhd_layer';
 import { update_cat, update_selected_cats } from '../global_variables/cat';
 import { update_cell_exp_array } from '../global_variables/cell_exp_array';
 import { update_selected_genes } from '../global_variables/selected_genes';
@@ -32,46 +31,65 @@ export const update_ist_landscape_from_cgm = async (
   // add try catch block
   try {
     if (click_type === 'row_label') {
+      if (click_info.value.entity === 'cell') {
+        inst_gene = 'cluster';
+        new_cat = click_info.value.name;
 
-      inst_gene = click_info.value.name;
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      new_cat = inst_gene === viz_state.cats.cat ? 'cluster' : inst_gene;
+        refresh_layer(viz_state, layers_obj, 'cell_layer');
+      } else {
+        inst_gene = click_info.value.name;
 
-      update_cat(viz_state.cats, new_cat);
-      update_selected_genes(viz_state.genes, [inst_gene], viz_state.obs_store);
-      // update_selected_cats(viz_state.cats, [], viz_state.obs_store);
-      update_selected_cats(
-        viz_state.cats,
-        new_cat === 'cluster' ? [] : [inst_gene],
-        viz_state.obs_store
-      );
+        new_cat = inst_gene === viz_state.cats.cat ? 'cluster' : inst_gene;
 
-      await update_cell_exp_array(
-        viz_state.cats,
-        viz_state.genes,
-        viz_state.global_base_url,
-        inst_gene,
-        viz_state.seg.version,
-        viz_state.vector_name_integer,
-        viz_state.aws
-      );
+        update_cat(viz_state.cats, new_cat);
+        update_selected_genes(viz_state.genes, [inst_gene], viz_state.obs_store);
+        update_selected_cats(
+          viz_state.cats,
+          new_cat === 'cluster' ? [] : [inst_gene],
+          viz_state.obs_store
+        );
+
+        await update_cell_exp_array(
+          viz_state.cats,
+          viz_state.genes,
+          viz_state.global_base_url,
+          inst_gene,
+          viz_state.seg.version,
+          viz_state.vector_name_integer,
+          viz_state.aws
+        );
+      }
     } else if (click_type === 'col_label') {
-      inst_gene = 'cluster';
-      new_cat = click_info.value.name;
+      if (click_info.value.entity === 'nbhd') {
+        const new_nbhd = click_info.value.name;
+        viz_state.obs_store.selected_nbhds.set([new_nbhd]);
+        refresh_layer(viz_state, layers_obj, 'nbhd_layer');
+      } else {
+        inst_gene = 'cluster';
+        new_cat = click_info.value.name;
 
-      update_cat(viz_state.cats, 'cluster');
-      update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
-      update_selected_genes(viz_state.genes, [], viz_state.obs_store);
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, [new_cat], viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      refresh_layer(viz_state, layers_obj, "cell_layer");
+        refresh_layer(viz_state, layers_obj, 'cell_layer');
+      }
     } else if (click_type === 'col_dendro') {
       const new_cats = click_info.value.selected_names;
+      if (click_info.value.entity === 'nbhd') {
+        viz_state.obs_store.selected_nbhds.set(new_cats);
+        refresh_layer(viz_state, layers_obj, 'nbhd_layer');
+      } else {
+        update_cat(viz_state.cats, 'cluster');
+        update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
+        update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
-      update_cat(viz_state.cats, 'cluster');
-      update_selected_cats(viz_state.cats, new_cats, viz_state.obs_store);
-      update_selected_genes(viz_state.genes, [], viz_state.obs_store);
-
-      refresh_layer(viz_state, layers_obj, "cell_layer");
+        refresh_layer(viz_state, layers_obj, 'cell_layer');
+      }
     }
   } catch (error) {
     handleAsyncError(error, {

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -89,6 +89,8 @@ class Landscape(anywidget.AnyWidget):
     meta_cluster = traitlets.Dict({}).tag(sync=True)
     landscape_state = traitlets.Unicode("spatial").tag(sync=True)
 
+    entity = traitlets.Unicode("CELL").tag(sync=True)
+
     update_trigger = traitlets.Dict().tag(sync=True)
     cell_clusters = traitlets.Dict({}).tag(sync=True)
 
@@ -376,6 +378,7 @@ class Clustergram(anywidget.AnyWidget):
     width = traitlets.Int(600).tag(sync=True)
     height = traitlets.Int(600).tag(sync=True)
     click_info = traitlets.Dict({}).tag(sync=True)
+    entity = traitlets.Unicode("CELL").tag(sync=True)
     selected_genes = traitlets.List(default_value=[]).tag(sync=True)
     top_n_genes = traitlets.Int(50).tag(sync=True)
 


### PR DESCRIPTION
## Summary
- add `entity` trait to Clustergram and Landscape widgets
- pass entity through matrix and landscape renders
- include entity info in clustergram click events and landscape updates

## Testing
- `npm test` *(fails: ModuleNotFoundError: No module named 'polars')*


------
https://chatgpt.com/codex/tasks/task_b_6899c3b2aa848326a296253852cda167