### PR TITLE
feat: add point-cloud visualization

### DIFF
--- a/js/deck-gl/core/deck_ist.js
+++ b/js/deck-gl/core/deck_ist.js
@@ -1,4 +1,4 @@
-import { Deck } from 'deck.gl';
+import { Deck, OrbitController } from 'deck.gl';
 
 import { make_tooltip } from '../utils/tooltips';
 
@@ -11,10 +11,15 @@ const getCursor = ({ isDragging }) => {
   return 'pointer';
 };
 
-export const ini_deck = (root, width, height) => {
+export const ini_deck = (root, width, height, technology = '') => {
+  const controller = { doubleClickZoom: false };
+  if (technology === 'point-cloud') {
+    controller.type = OrbitController;
+  }
+
   const deck_ist = new Deck({
     parent: root,
-    controller: { doubleClickZoom: false },
+    controller,
     getCursor,
     width,
     height,
@@ -55,11 +60,17 @@ export const set_initial_view_state = (
   ini_zoom,
   viz_state
 ) => {
-  const { center_x, center_y, ini_zoom: initial_zoom } = viz_state.spatial;
+  const {
+    center_x,
+    center_y,
+    center_z = 0,
+    ini_zoom: initial_zoom,
+  } = viz_state.spatial;
 
-  if (ini_x === 0 && ini_y === 0 && ini_zoom === 0) {
+  if (ini_x === 0 && ini_y === 0 && ini_z === 0 && ini_zoom === 0) {
     ini_x = center_x;
     ini_y = center_y;
+    ini_z = center_z;
     ini_zoom = initial_zoom;
   }
 

--- a/js/deck-gl/core/views.js
+++ b/js/deck-gl/core/views.js
@@ -1,5 +1,8 @@
-import { OrthographicView } from 'deck.gl';
+import { OrthographicView, OrbitView } from 'deck.gl';
 
-export const set_views = () => {
+export const set_views = (technology = '') => {
+  if (technology === 'point-cloud') {
+    return [new OrbitView({ id: 'orbit' })];
+  }
   return [new OrthographicView({ id: 'ortho' })];
 };

--- a/js/deck-gl/layers/cell_layer.js
+++ b/js/deck-gl/layers/cell_layer.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { ScatterplotLayer } from 'deck.gl';
+import { ScatterplotLayer, PointCloudLayer } from 'deck.gl';
 
 import {
   set_cell_cats,
@@ -132,13 +132,16 @@ export const ini_cell_layer = async (base_url, viz_state) => {
 
   const flatCoordinateArray =
     viz_state.spatial.cell_scatter_data.attributes.getPosition.value;
+  const dim =
+    viz_state.spatial.cell_scatter_data.attributes.getPosition.size || 2;
 
   // save cell positions and categories in one place for updating cluster bar plot
   viz_state.combo_data.cell = new_cell_names_array.map((name, index) => ({
     name,
     cat: viz_state.cats.dict_cell_cats[name],
-    x: flatCoordinateArray[index * 2],
-    y: flatCoordinateArray[index * 2 + 1],
+    x: flatCoordinateArray[index * dim],
+    y: flatCoordinateArray[index * dim + 1],
+    z: dim === 3 ? flatCoordinateArray[index * dim + 2] : 0,
   }));
 
   let cell_scatter_data_objects;
@@ -159,7 +162,14 @@ export const ini_cell_layer = async (base_url, viz_state) => {
     // convert to easier to use objects
     const numRows = viz_state.spatial.cell_scatter_data.length; // Replace with arrow_table.numRows
     cell_scatter_data_objects = Array.from({ length: numRows }, (_, i) => ({
-      position: [flatCoordinateArray[i * 2], flatCoordinateArray[i * 2 + 1]],
+      position:
+        dim === 3
+          ? [
+              flatCoordinateArray[i * dim],
+              flatCoordinateArray[i * dim + 1],
+              flatCoordinateArray[i * dim + 2],
+            ]
+          : [flatCoordinateArray[i * dim], flatCoordinateArray[i * dim + 1]],
       umap: [
         flatCoordinateArray_umap[i * 2],
         flatCoordinateArray_umap[i * 2 + 1],
@@ -178,6 +188,14 @@ export const ini_cell_layer = async (base_url, viz_state) => {
     viz_state.spatial.y_max = d3.max(
       cell_scatter_data_objects.map((d) => d.position[1])
     );
+    if (dim === 3) {
+      viz_state.spatial.z_min = d3.min(
+        cell_scatter_data_objects.map((d) => d.position[2])
+      );
+      viz_state.spatial.z_max = d3.max(
+        cell_scatter_data_objects.map((d) => d.position[2])
+      );
+    }
 
     cell_scatter_data_objects = scale_umap_data(
       viz_state,
@@ -186,7 +204,14 @@ export const ini_cell_layer = async (base_url, viz_state) => {
   } else {
     const numRows = viz_state.spatial.cell_scatter_data.length; // Replace with arrow_table.numRows
     cell_scatter_data_objects = Array.from({ length: numRows }, (_, i) => ({
-      position: [flatCoordinateArray[i * 2], flatCoordinateArray[i * 2 + 1]],
+      position:
+        dim === 3
+          ? [
+              flatCoordinateArray[i * dim],
+              flatCoordinateArray[i * dim + 1],
+              flatCoordinateArray[i * dim + 2],
+            ]
+          : [flatCoordinateArray[i * dim], flatCoordinateArray[i * dim + 1]],
     }));
 
     viz_state.spatial.x_min = d3.min(
@@ -201,12 +226,26 @@ export const ini_cell_layer = async (base_url, viz_state) => {
     viz_state.spatial.y_max = d3.max(
       cell_scatter_data_objects.map((d) => d.position[1])
     );
+    if (dim === 3) {
+      viz_state.spatial.z_min = d3.min(
+        cell_scatter_data_objects.map((d) => d.position[2])
+      );
+      viz_state.spatial.z_max = d3.max(
+        cell_scatter_data_objects.map((d) => d.position[2])
+      );
+    }
   }
 
   viz_state.spatial.center_x =
     (viz_state.spatial.x_max + viz_state.spatial.x_min) / 2;
   viz_state.spatial.center_y =
     (viz_state.spatial.y_max + viz_state.spatial.y_min) / 2;
+  if (dim === 3) {
+    viz_state.spatial.center_z =
+      (viz_state.spatial.z_max + viz_state.spatial.z_min) / 2;
+    viz_state.spatial.data_depth =
+      viz_state.spatial.z_max - viz_state.spatial.z_min;
+  }
 
   viz_state.spatial.data_width =
     viz_state.spatial.x_max - viz_state.spatial.x_min;
@@ -232,6 +271,9 @@ export const ini_cell_layer = async (base_url, viz_state) => {
     viz_state.spatial.ini_zoom = Math.log2(viz_state.spatial.scale) * 1.01;
     viz_state.spatial.ini_x = viz_state.spatial.center_x;
     viz_state.spatial.ini_y = viz_state.spatial.center_y;
+    if (dim === 3) {
+      viz_state.spatial.ini_z = viz_state.spatial.center_z;
+    }
   } else {
     viz_state.spatial.ini_zoom = Math.log2(canvas_width / 5000) * 0.95;
     viz_state.spatial.ini_x = 5000;
@@ -247,20 +289,38 @@ export const ini_cell_layer = async (base_url, viz_state) => {
     },
   };
 
-  const cell_layer = new ScatterplotLayer({
-    id: 'cell-layer',
-    radiusMinPixels: 1,
-    getRadius: 5.0,
-    pickable: true,
-    getFillColor: (i, d) => get_cell_color(viz_state.cats, i, d),
-    data: viz_state.spatial.cell_scatter_data_objects,
-    transitions,
-    getPosition: (d) =>
-      viz_state.obs_store.umap_state.get() ? d.umap : d.position,
-    updateTriggers: {
-      getPosition: [viz_state.obs_store.umap_state.get()],
-    },
-  });
+  let cell_layer;
+  if (viz_state.img.landscape_parameters.technology === 'point-cloud') {
+    cell_layer = new PointCloudLayer({
+      id: 'cell-layer',
+      pointSize: 1,
+      pickable: true,
+      getColor: (i, d) => get_cell_color(viz_state.cats, i, d),
+      data: viz_state.spatial.cell_scatter_data_objects,
+      transitions,
+      getPosition: (d) =>
+        viz_state.obs_store.umap_state.get() ? d.umap : d.position,
+      updateTriggers: {
+        getPosition: [viz_state.obs_store.umap_state.get()],
+      },
+      opacity: 0.5,
+    });
+  } else {
+    cell_layer = new ScatterplotLayer({
+      id: 'cell-layer',
+      radiusMinPixels: 1,
+      getRadius: 5.0,
+      pickable: true,
+      getFillColor: (i, d) => get_cell_color(viz_state.cats, i, d),
+      data: viz_state.spatial.cell_scatter_data_objects,
+      transitions,
+      getPosition: (d) =>
+        viz_state.obs_store.umap_state.get() ? d.umap : d.position,
+      updateTriggers: {
+        getPosition: [viz_state.obs_store.umap_state.get()],
+      },
+    });
+  }
 
   return cell_layer;
 };
@@ -278,10 +338,16 @@ export const new_toggle_cell_layer_visibility = (layers_obj, visible) => {
   });
 };
 
-export const update_cell_layer_radius = (layers_obj, radius) => {
-  layers_obj.cell_layer = layers_obj.cell_layer.clone({
-    getRadius: radius,
-  });
+export const update_cell_layer_radius = (layers_obj, radius, viz_state) => {
+  if (viz_state.img.landscape_parameters.technology === 'point-cloud') {
+    layers_obj.cell_layer = layers_obj.cell_layer.clone({
+      pointSize: radius / 10,
+    });
+  } else {
+    layers_obj.cell_layer = layers_obj.cell_layer.clone({
+      getRadius: radius,
+    });
+  }
 };
 
 export const update_cell_pickable_state = (layers_obj, pickable) => {

--- a/js/read_parquet/get_scatter_data.js
+++ b/js/read_parquet/get_scatter_data.js
@@ -13,10 +13,12 @@ export const get_scatter_data = (arrow_table) => {
         return combined;
       }, new Float64Array(0));
 
+    const size = flatCoordinateArray.length / arrow_table.numRows;
+
     const scatter_data = {
       length: arrow_table.numRows,
       attributes: {
-        getPosition: { value: flatCoordinateArray, size: 2 },
+        getPosition: { value: flatCoordinateArray, size },
       },
     };
 

--- a/js/ui/sliders.js
+++ b/js/ui/sliders.js
@@ -28,7 +28,8 @@ const cell_slider_callback = async (deck_ist, layers_obj, viz_state) => {
 
   update_cell_layer_radius(
     layers_obj,
-    viz_state.sliders.cell.value / scale_down_cell_radius
+    viz_state.sliders.cell.value / scale_down_cell_radius,
+    viz_state
   );
 
   refresh_layer(viz_state, layers_obj, 'cell_layer');

--- a/js/ui/ui_containers.js
+++ b/js/ui/ui_containers.js
@@ -380,8 +380,9 @@ export const make_ist_ui_container = (
     'row'
   );
 
-  const isChromium =
-    viz_state.img.landscape_parameters.technology === 'Chromium';
+  const isChromium = ['Chromium', 'point-cloud'].includes(
+    viz_state.img.landscape_parameters.technology
+  );
 
   if (isChromium) {
     make_button(

--- a/js/umap/scale_umap_data.js
+++ b/js/umap/scale_umap_data.js
@@ -9,7 +9,11 @@ export const scale_umap_data = (viz_state, cell_scatter_data_objects) => {
   let x_max;
   let y_min;
   let y_max;
-  if (viz_state.img.landscape_parameters.technology === 'Chromium') {
+  if (
+    ['Chromium', 'point-cloud'].includes(
+      viz_state.img.landscape_parameters.technology
+    )
+  ) {
     x_min = 0;
     x_max = 10000;
     y_min = 0;

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -311,7 +311,7 @@ export const landscape_ist = async (
 
   await set_landscape_parameters(viz_state.img, base_url, viz_state.aws);
   const tech = viz_state.img.landscape_parameters.technology;
-  if (tech === 'Chromium') {
+  if (tech === 'Chromium' || tech === 'point-cloud') {
     viz_state.obs_store.viz_image_layers.set(false);
     viz_state.obs_store.viz_background_layer.set(false);
   }
@@ -337,7 +337,7 @@ export const landscape_ist = async (
   root.style.height = `${height}px`;
   root.style.border = '1px solid #d3d3d3';
 
-  if (tech === 'Chromium') {
+  if (tech === 'Chromium' || tech === 'point-cloud') {
     viz_state.dimensions = { width: 1, height: 1, tileSize: 1 };
   } else {
     await set_dimensions(viz_state, base_url, imgage_name_for_dim);
@@ -352,9 +352,9 @@ export const landscape_ist = async (
 
   await set_cluster_metadata(viz_state);
 
-  viz_state.views = set_views();
+  viz_state.views = set_views(tech);
 
-  const deck_ist = await ini_deck(root, width, height);
+  const deck_ist = await ini_deck(root, width, height, tech);
   // set_initial_view_state(deck_ist, ini_x, ini_y, ini_z, ini_zoom)
   set_views_prop(deck_ist, viz_state.views);
 
@@ -595,8 +595,9 @@ export const landscape_ist = async (
   el.appendChild(ui_container);
   el.appendChild(root);
 
-  const isChromium =
-    viz_state.img.landscape_parameters.technology === 'Chromium';
+  const isChromium = ['Chromium', 'point-cloud'].includes(
+    viz_state.img.landscape_parameters.technology
+  );
   viz_state.obs_store.landscape_view.subscribe(
     (view) => {
       const isUmap = view === 'umap';

--- a/js/widget.js
+++ b/js/widget.js
@@ -51,6 +51,8 @@ const render_landscape_ist = async ({ model, el }) => {
   let landscape_state = model.get('landscape_state');
   if (technology === 'Chromium') {
     landscape_state = 'umap';
+  } else if (technology === 'point-cloud') {
+    landscape_state = 'spatial';
   }
   const segmentation = model.get('segmentation');
 
@@ -139,7 +141,7 @@ const render_landscape_h_e = async ({ model, el }) => {
 const render_landscape = async ({ model, el }) => {
   const technology = model.get('technology');
 
-  if (['MERSCOPE', 'Xenium', 'Chromium'].includes(technology)) {
+  if (['MERSCOPE', 'Xenium', 'Chromium', 'point-cloud'].includes(technology)) {
     return render_landscape_ist({ model, el });
   } else if (['Visium-HD'].includes(technology)) {
     return render_landscape_sst({ model, el });


### PR DESCRIPTION
## Summary
- add `point-cloud` technology using PointCloudLayer and OrbitView
- support variable-dimension scatter data for 3D coordinates
- wire UI and view logic to handle `point-cloud` datasets

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d2cba4138832aae8d10c590424e04