### PR TITLE
Fix widget sync by checking model methods

### DIFF
--- a/js/deck-gl/layers/edit_layer.js
+++ b/js/deck-gl/layers/edit_layer.js
@@ -55,7 +55,7 @@ const calc_region_areas = (featureCollection) => {
 };
 
 export const sync_region_to_model = (viz_state) => {
-  if (Object.keys(viz_state.model).length > 0) {
+  if (viz_state.model?.set) {
     if (viz_state.nbhd?.edit) {
       viz_state.model.set('nbhd_geojson', {});
       viz_state.model.set('nbhd_geojson', viz_state.edit.feature_collection);

--- a/js/deck-gl/matrix/dendro_layers.js
+++ b/js/deck-gl/matrix/dendro_layers.js
@@ -52,7 +52,7 @@ const dendro_layer_onclick = (event, deck_mat, layers_mat, viz_state, axis) => {
     attribute: viz_state.attribute[axis],
   };
 
-  if (Object.keys(viz_state.model).length > 0) {
+  if (viz_state.model?.set) {
     viz_state.model.set('click_info', null);
     viz_state.model.set('click_info', viz_state.click);
     viz_state.model.save_changes();

--- a/js/deck-gl/matrix/label_layers.js
+++ b/js/deck-gl/matrix/label_layers.js
@@ -222,7 +222,7 @@ const row_label_layer_onclick = (event, deck_mat, layers_mat, viz_state) => {
       viz_state.labels.clicks.row = 0;
     }, DOUBLE_CLICK_DELAY);
 
-    if (Object.keys(viz_state.model).length > 0) {
+    if (viz_state.model?.set) {
       viz_state.model.set('click_info', null);
       viz_state.model.set('click_info', viz_state.click);
       viz_state.model.save_changes();
@@ -261,7 +261,7 @@ const col_label_layer_onclick = (event, deck_mat, layers_mat, viz_state) => {
       viz_state.labels.clicks.col = 0;
     }, DOUBLE_CLICK_DELAY);
 
-    if (Object.keys(viz_state.model).length > 0) {
+    if (viz_state.model?.set) {
       viz_state.model.set('click_info', null);
       viz_state.model.set('click_info', viz_state.click);
       viz_state.model.save_changes();

--- a/js/deck-gl/matrix/mat_layer.js
+++ b/js/deck-gl/matrix/mat_layer.js
@@ -60,7 +60,7 @@ const mat_layer_onclick = (event, deck_mat, layers_mat, viz_state) => {
     },
   };
 
-  if (Object.keys(viz_state.model).length > 0) {
+  if (viz_state.model?.set) {
     viz_state.model.set('click_info', null);
     viz_state.model.set('click_info', viz_state.click);
     viz_state.model.save_changes();

--- a/js/ui/bar_plot.js
+++ b/js/ui/bar_plot.js
@@ -20,7 +20,7 @@ export const bar_callback_cat = (
   _viz_state
 ) => {
   // ensure that cell button, slider and bars are active
-  _viz_state.buttons.buttons.cell.style('color', 'blue');
+  _viz_state.buttons?.buttons?.cell?.style?.('color', 'blue');
 
   toggle_slider(_viz_state.sliders.cell, true);
   _viz_state.cats.svg_bar_cluster.selectAll('rect').style('opacity', 1.0);
@@ -31,7 +31,7 @@ export const bar_callback_cat = (
     _viz_state.obs_store.viz_edit_layer.set(false);
     // wrap in try
     try {
-      _viz_state.buttons.buttons.nbhd.style('color', 'gray');
+      _viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
       toggle_slider(_viz_state.sliders.nbhd, false);
     } catch {
       // intentionally ignore missing neighborhood button
@@ -66,7 +66,7 @@ export const bar_callback_gene = async (
   _viz_state
 ) => {
   // ensure that trx button, slider, and bars are active
-  _viz_state.buttons.buttons.trx.style('color', 'blue');
+  _viz_state.buttons?.buttons?.trx?.style?.('color', 'blue');
 
   toggle_slider(_viz_state.sliders.trx, true);
   _viz_state.genes.svg_bar_gene.selectAll('rect').style('opacity', 1.0);
@@ -78,7 +78,7 @@ export const bar_callback_gene = async (
     _viz_state.obs_store.viz_edit_layer.set(false);
     // wrap in try
     try {
-      _viz_state.buttons.buttons.nbhd.style('color', 'gray');
+      _viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
       toggle_slider(_viz_state.sliders.nbhd, false);
     } catch {
       // intentionally ignore missing neighborhood button
@@ -129,7 +129,7 @@ export const bar_callback_nbhd = (
   if (_viz_state.nbhd.edit) {
     _viz_state.obs_store.viz_edit_layer.set(true);
 
-    _viz_state.buttons.buttons.nbhd.style('color', 'blue');
+    _viz_state.buttons?.buttons?.nbhd?.style?.('color', 'blue');
     toggle_slider(_viz_state.sliders.nbhd, true);
 
     const prev_selected_nbhds = _viz_state.obs_store.selected_nbhds.get();
@@ -169,7 +169,7 @@ export const bar_callback_nbhd = (
     _viz_state.obs_store.viz_nbhd_layer.set(true);
     _viz_state.obs_store.viz_edit_layer.set(false);
 
-    _viz_state.buttons.buttons.nbhd.style('color', 'blue');
+    _viz_state.buttons?.buttons?.nbhd?.style?.('color', 'blue');
 
     const prev_selected_nbhds = _viz_state.obs_store.selected_nbhds.get();
     if (

--- a/js/ui/text_buttons.js
+++ b/js/ui/text_buttons.js
@@ -222,7 +222,7 @@ const trx_button_callback_ist = async (
     viz_state.obs_store.viz_edit_layer.set(false);
 
     if (viz_state.nbhd.is_nbhd) {
-      viz_state.buttons.buttons.nbhd.style('color', 'gray');
+      viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
     }
 
     viz_state.genes.svg_bar_gene.selectAll('rect').style('opacity', 1.0);
@@ -256,7 +256,7 @@ const cell_button_callback = async (event, deck_ist, layers_obj, viz_state) => {
     viz_state.obs_store.viz_edit_layer.set(false);
 
     if (viz_state.nbhd.is_nbhd) {
-      viz_state.buttons.buttons.nbhd.style('color', 'gray');
+      viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
     }
 
     viz_state.cats.svg_bar_cluster.selectAll('rect').style('opacity', 1.0);

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -172,7 +172,7 @@ export const landscape_ist = async (
     viz_state.aws = null;
   }
 
-  if (Object.keys(viz_state.model).length !== 0) {
+  if (viz_state.model?.get) {
     if (Object.keys(nbhd).length === 0) {
       viz_state.nbhd.is_nbhd = nbhd_edit;
 
@@ -379,7 +379,7 @@ export const landscape_ist = async (
   viz_state.edit.visible = false;
   viz_state.edit.modify_index = null;
 
-  if (Object.keys(viz_state.model).length !== 0) {
+  if (viz_state.model?.get) {
     if (Object.keys(viz_state.model.get('region')).length === 0) {
       viz_state.edit.feature_collection = {
         type: 'FeatureCollection',
@@ -578,7 +578,7 @@ export const landscape_ist = async (
 
   set_deck_on_view_state_change(deck_ist, layers_obj, viz_state);
 
-  if (Object.keys(viz_state.model).length > 0) {
+  if (viz_state.model?.on) {
     viz_state.model.on('change:update_trigger', () =>
       update_ist_landscape_from_cgm(deck_ist, layers_obj, viz_state)
     );

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -446,6 +446,7 @@ export const landscape_ist = async (
 
         viz_state.buttons.buttons.cell.style('color', 'gray');
         viz_state.buttons.buttons.trx.style('color', 'gray');
+        viz_state.buttons.buttons.nbhd?.style('color', 'blue');
 
         toggle_slider(viz_state.sliders.cell, false);
         toggle_slider(viz_state.sliders.trx, false);
@@ -461,6 +462,7 @@ export const landscape_ist = async (
 
         viz_state.buttons.buttons.cell.style('color', 'blue');
         viz_state.buttons.buttons.trx.style('color', 'blue');
+        viz_state.buttons.buttons.nbhd?.style('color', 'gray');
 
         toggle_slider(viz_state.sliders.cell, true);
         toggle_slider(viz_state.sliders.trx, true);

--- a/js/viz/landscape_sst.js
+++ b/js/viz/landscape_sst.js
@@ -209,7 +209,7 @@ export const landscape_sst = async (
     initialViewState: initial_view_state,
   });
 
-  if (Object.keys(viz_state.model).length > 0) {
+  if (viz_state.model?.on) {
     // ist version
     viz_state.model.on('change:update_trigger', () =>
       update_tile_landscape_from_cgm(deck_sst, layers_sst, viz_state)

--- a/js/widget_interactions/update_ist_landscape_from_cgm.js
+++ b/js/widget_interactions/update_ist_landscape_from_cgm.js
@@ -43,7 +43,7 @@ export const update_ist_landscape_from_cgm = async (
         update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
         viz_state.obs_store.viz_nbhd_layer.set(false);
-        viz_state.buttons.buttons.nbhd.style('color', 'gray');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
 
         refresh_layer(viz_state, layers_obj, 'cell_layer');
       } else {
@@ -74,7 +74,7 @@ export const update_ist_landscape_from_cgm = async (
         );
 
         viz_state.obs_store.viz_nbhd_layer.set(false);
-        viz_state.buttons.buttons.nbhd.style('color', 'gray');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
 
         refresh_layer(viz_state, layers_obj, 'cell_layer');
         refresh_layer(viz_state, layers_obj, 'trx_layer');
@@ -84,7 +84,7 @@ export const update_ist_landscape_from_cgm = async (
         const new_nbhd = click_info.value.name;
         viz_state.obs_store.selected_nbhds.set([new_nbhd]);
         viz_state.obs_store.viz_nbhd_layer.set(true);
-        viz_state.buttons.buttons.nbhd.style('color', 'blue');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'blue');
 
         refresh_layer(viz_state, layers_obj, 'nbhd_layer');
         refresh_layer(viz_state, layers_obj, 'cell_layer');
@@ -116,7 +116,7 @@ export const update_ist_landscape_from_cgm = async (
         update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
         viz_state.obs_store.viz_nbhd_layer.set(false);
-        viz_state.buttons.buttons.nbhd.style('color', 'gray');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
 
         refresh_layer(viz_state, layers_obj, 'cell_layer');
         refresh_layer(viz_state, layers_obj, 'nbhd_layer');
@@ -127,7 +127,7 @@ export const update_ist_landscape_from_cgm = async (
       if (click_info.value.entity === 'nbhd') {
         viz_state.obs_store.selected_nbhds.set(new_cats);
         viz_state.obs_store.viz_nbhd_layer.set(true);
-        viz_state.buttons.buttons.nbhd.style('color', 'blue');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'blue');
         refresh_layer(viz_state, layers_obj, 'nbhd_layer');
 
         if (viz_state.obs_store.selected_nbhds.get().length > 0) {
@@ -156,7 +156,7 @@ export const update_ist_landscape_from_cgm = async (
         update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
         viz_state.obs_store.viz_nbhd_layer.set(false);
-        viz_state.buttons.buttons.nbhd.style('color', 'gray');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
 
         refresh_layer(viz_state, layers_obj, 'cell_layer');
       }
@@ -168,7 +168,7 @@ export const update_ist_landscape_from_cgm = async (
         update_selected_genes(viz_state.genes, [], viz_state.obs_store);
 
         viz_state.obs_store.viz_nbhd_layer.set(false);
-        viz_state.buttons.buttons.nbhd.style('color', 'gray');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
 
         refresh_layer(viz_state, layers_obj, 'cell_layer');
         refresh_layer(viz_state, layers_obj, 'trx_layer');
@@ -204,7 +204,7 @@ export const update_ist_landscape_from_cgm = async (
         }
 
         viz_state.obs_store.viz_nbhd_layer.set(false);
-        viz_state.buttons.buttons.nbhd.style('color', 'gray');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'gray');
 
         refresh_layer(viz_state, layers_obj, 'cell_layer');
         refresh_layer(viz_state, layers_obj, 'trx_layer');
@@ -215,7 +215,7 @@ export const update_ist_landscape_from_cgm = async (
         const new_nbhds = [row.name, col.name];
         viz_state.obs_store.selected_nbhds.set(new_nbhds);
         viz_state.obs_store.viz_nbhd_layer.set(true);
-        viz_state.buttons.buttons.nbhd.style('color', 'blue');
+        viz_state.buttons?.buttons?.nbhd?.style?.('color', 'blue');
         refresh_layer(viz_state, layers_obj, 'nbhd_layer');
 
         if (viz_state.obs_store.selected_nbhds.get().length > 0) {


### PR DESCRIPTION
## Summary
- Ensure landscape widgets attach update listeners when a model with event hooks is present
- Guard click info updates in matrix layers by verifying the model has set()

## Testing
- `npm test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_b_68adcc850ef8832699ae504927e3f2c9