### PR TITLE
Fix H&E image tile loading with AWS credentials

### DIFF
--- a/js/deck-gl/layers/simple_image_layer.js
+++ b/js/deck-gl/layers/simple_image_layer.js
@@ -25,7 +25,8 @@ export const make_simple_image_layer = async (viz_state, info) => {
       info.name,
       image_format,
       landscape_parameters.max_pyramid_zoom,
-      options
+      options,
+      viz_state.aws
     ),
     renderSubLayers: create_simple_render_tile_sublayers(dimensions),
     visible: true,


### PR DESCRIPTION
## Summary
- pass AWS credentials when requesting H&E tile images so private buckets load correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dfed412680832abb95e3380ef2713d