### PR TITLE
Simplify manual category syncing

### DIFF
--- a/js/viz/matrix_viz.js
+++ b/js/viz/matrix_viz.js
@@ -203,24 +203,17 @@ export const matrix_viz = async (
   // ---------------------------------------------------------------------------
   // JS -> PY sync: manual_cat + category_colors
   // ---------------------------------------------------------------------------
-  const sync_axes_to_traitlets = (axes) => {
+  const manual_stores = viz_state.obs_store?.manual_cat || {}
+
+  const sync_manual_traitlets = () => {
     if (!viz_state.model) return
 
-    const axis_list = Array.isArray(axes) ? axes : [axes]
-    console.log('sync_axes_to_traitlets', axis_list)
-
-    const row_store = viz_state.obs_store?.manual_cat?.row
-    const col_store = viz_state.obs_store?.manual_cat?.col
-
     const payload = {
-      row: row_store ? row_store.toExportPayload() : {},
-      col: col_store ? col_store.toExportPayload() : {},
+      row: manual_stores.row ? manual_stores.row.toExportPayload() : {},
+      col: manual_stores.col ? manual_stores.col.toExportPayload() : {},
     }
 
-    const json = JSON.stringify(payload)
-
-    // Primary sources of truth for Python
-    viz_state.model.set('manual_cat', json)
+    viz_state.model.set('manual_cat', JSON.stringify(payload))
     viz_state.model.set(
       'category_colors',
       viz_state.attr.category_colors || {}
@@ -237,25 +230,21 @@ export const matrix_viz = async (
     refresh_attribute_layers(deck_mat, layers_mat, viz_state)
 
     if (sync) {
-      sync_axes_to_traitlets(axis)
+      sync_manual_traitlets()
     }
   }
 
   // Whenever the JS manual_cat stores change (editor/dendro/etc.), repaint + sync
-  if (viz_state.obs_store?.manual_cat) {
-    ;['row', 'col'].forEach((axis) => {
-      const manual_store = viz_state.obs_store.manual_cat[axis]
-      if (!manual_store) return
+  Object.entries(manual_stores).forEach(([axis, store]) => {
+    if (!store || !['row', 'col'].includes(axis)) return
 
-      manual_store.subscribe(
-        () => {
-          // Apply to JS state and then sync back to Python
-          apply_manual_and_refresh(axis, { sync: true })
-        },
-        { immediate: false }
-      )
-    })
-  }
+    store.subscribe(
+      () => {
+        apply_manual_and_refresh(axis, { sync: true })
+      },
+      { immediate: false }
+    )
+  })
 
   // ---------------------------------------------------------------------------
   // PYTHON -> JS one-way pieces
@@ -277,48 +266,40 @@ export const matrix_viz = async (
     viz_state.model.save_changes()
 
     // 2) ONE-TIME: manual categories bootstrap (PY -> JS), then sync back once
-    const bootstrap_manual_categories = () => {
-      viz_state.manual_cat = viz_state.manual_cat || { config: {}, flags: {} }
-
-      // manual_cat_config may be JSON string or object
-      let raw_config = viz_state.model.get('manual_cat_config')
-      let parsed = raw_config
-      if (typeof parsed === 'string') {
-        try {
-          parsed = parsed ? JSON.parse(parsed) : {}
-        } catch {
-          parsed = {}
-        }
+    const parseJSON = (value, fallback) => {
+      if (!value) return fallback
+      if (typeof value === 'object') return value
+      try {
+        return JSON.parse(value)
+      } catch {
+        return fallback
       }
+    }
 
-      const normalized =
-        parsed && typeof parsed === 'object' ? parsed : { row: null, col: null }
+    const bootstrap_manual_categories = () => {
+      const config =
+        parseJSON(viz_state.model.get('manual_cat_config'), {
+          row: null,
+          col: null,
+        }) || {}
 
-      viz_state.manual_cat.config.row = normalized.row || null
-      viz_state.manual_cat.config.col = normalized.col || null
-
-      viz_state.manual_cat.flags = {
+      const flags = {
         row: !!viz_state.model.get('manual_row_cat'),
         col: !!viz_state.model.get('manual_col_cat'),
       }
 
       ;['row', 'col'].forEach((axis) => {
-        if (!viz_state.manual_cat.flags[axis]) return
+        if (!flags[axis]) return
 
-        const store = viz_state.obs_store?.manual_cat?.[axis]
-        const attribute_name =
-          viz_state.manual_cat.config?.[axis]?.attribute || null
-
+        const store = manual_stores[axis]
         if (store) {
-          store.setAttribute(attribute_name)
+          store.setAttribute(config?.[axis]?.attribute || null)
         }
 
-        // Build initial bars, but don't echo back yet
         apply_manual_and_refresh(axis, { sync: false })
       })
 
-      // Let Python see the initial JS state (frames/colors + manual_cat)
-      sync_axes_to_traitlets(['row', 'col'])
+      sync_manual_traitlets()
     }
 
     bootstrap_manual_categories()

--- a/src/celldega/viz/widget.py
+++ b/src/celldega/viz/widget.py
@@ -3,7 +3,7 @@ Widget module for interactive visualization components.
 """
 
 import colorsys
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from contextlib import suppress
 from copy import deepcopy
 import json
@@ -30,6 +30,26 @@ _DEFAULT_MANUAL_ATTRIBUTE_TITLES = {
 }
 _MANUAL_FILL_VALUE = "N.A."
 _MANUAL_FILL_COLOR = "#d1d5db"
+
+
+def _json_dict_or_default(value, fallback=None):
+    """Parse *value* into a dict, falling back to ``fallback`` when invalid."""
+
+    if fallback is None:
+        fallback = {}
+
+    if not value:
+        return deepcopy(fallback)
+
+    if isinstance(value, Mapping):
+        return dict(value)
+
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return deepcopy(fallback)
+
+    return parsed if isinstance(parsed, Mapping) else deepcopy(fallback)
 
 
 def _hsv_to_hex(h: float) -> str:
@@ -607,9 +627,6 @@ class Clustergram(anywidget.AnyWidget):
         super().__init__(**kwargs)
         _clustergram_registry[name] = self
 
-        # Used to avoid echo loops when we mirror JS -> PY
-        self._manual_sync_block = False
-
         # ------------------------------------------------------------------
         # Initialize a simple manual_cat_config from the flags, if the user
         # didn't pass anything explicit.
@@ -641,16 +658,12 @@ class Clustergram(anywidget.AnyWidget):
         base_colors = dict(self.network_meta.get("global_cat_colors", {}))
         if getattr(self, "category_colors", None):
             base_colors.update(self.category_colors)
-        self._category_colors = base_colors
-        self.category_colors = deepcopy(self._category_colors)
+        self.category_colors = deepcopy(base_colors)
 
     @property
     def manual_cat_dict(self) -> dict:
         """Convenience accessor: parsed JSON from manual_cat."""
-        try:
-            return json.loads(self.manual_cat or "{}")
-        except json.JSONDecodeError:
-            return {}
+        return _json_dict_or_default(self.manual_cat)
 
     # ------------------------------------------------------------------
     # PY-only DataFrames derived from manual_cat JSON
@@ -658,12 +671,7 @@ class Clustergram(anywidget.AnyWidget):
     @traitlets.observe("manual_cat")
     def _on_manual_cat(self, change) -> None:
         """Rebuild backend DataFrames when manual_cat JSON changes."""
-        raw = change.get("new") or "{}"
-        try:
-            payload = json.loads(raw)
-        except json.JSONDecodeError:
-            payload = {}
-
+        payload = _json_dict_or_default(change.get("new"))
         self._update_manual_cat_frames(payload)
 
     def _update_manual_cat_frames(self, payload: dict) -> None:
@@ -677,72 +685,59 @@ class Clustergram(anywidget.AnyWidget):
         """
         for axis in ("row", "col"):
             axis_payload = payload.get(axis) or {}
-            if not axis_payload:
-                setattr(self, f"{axis}_manual_df", None)
-                setattr(self, f"{axis}_manual_colors_df", None)
-                continue
-
-            # --- values: name -> category -----------------------------------
-            attr_names = sorted(axis_payload.keys())
-
-            # union of all indices for this axis
-            index_labels = sorted(
-                {
-                    str(name)
-                    for attr in axis_payload.values()
-                    for name in (attr.get("values") or {}).keys()
-                }
-            )
-
-            if index_labels:
-                idx = pd.Index(index_labels, name=f"{axis}_id")
-                data = {}
-                for attr_name, spec in axis_payload.items():
-                    values = spec.get("values") or {}
-                    series = pd.Series(
-                        [values.get(label, _MANUAL_FILL_VALUE) for label in index_labels],
-                        index=idx,
-                        dtype=object,
-                    )
-                    data[str(attr_name)] = series
-                manual_df = pd.DataFrame(data, index=idx)
-            else:
-                manual_df = None
-
-            # --- colors: category -> hex per attribute ----------------------
-            cat_labels = sorted(
-                {
-                    str(cat)
-                    for attr in axis_payload.values()
-                    for cat in (attr.get("colors") or {}).keys()
-                }
-            )
-
-            if cat_labels:
-                cat_idx = pd.Index(cat_labels, name="category")
-                color_data = {}
-                for attr_name, spec in axis_payload.items():
-                    cmap = spec.get("colors") or {}
-                    series = pd.Series(
-                        [cmap.get(cat, None) for cat in cat_labels],
-                        index=cat_idx,
-                        dtype=object,
-                    )
-                    color_data[str(attr_name)] = series
-                colors_df = pd.DataFrame(color_data, index=cat_idx)
-            else:
-                colors_df = None
-
+            manual_df, colors_df = self._build_axis_manual_frames(axis, axis_payload)
             setattr(self, f"{axis}_manual_df", manual_df)
             setattr(self, f"{axis}_manual_colors_df", colors_df)
 
-    @property
-    def manual_cat_dict(self) -> dict:
-        """Convenience accessor: parsed JSON from manual_cat."""
-        try:
-            return json.loads(self.manual_cat or "{}")
-        except json.JSONDecodeError:
-            return {}
+    def _build_axis_manual_frames(self, axis: str, axis_payload: dict):
+        if not axis_payload:
+            return None, None
+
+        index_labels = sorted(
+            {
+                str(name)
+                for attr in axis_payload.values()
+                for name in (attr.get("values") or {}).keys()
+            }
+        )
+
+        manual_df = None
+        if index_labels:
+            idx = pd.Index(index_labels, name=f"{axis}_id")
+            data = {}
+            for attr_name, spec in axis_payload.items():
+                values = spec.get("values") or {}
+                series = pd.Series(
+                    [values.get(label, _MANUAL_FILL_VALUE) for label in index_labels],
+                    index=idx,
+                    dtype=object,
+                )
+                data[str(attr_name)] = series
+            manual_df = pd.DataFrame(data, index=idx)
+
+        cat_labels = sorted(
+            {
+                str(cat)
+                for attr in axis_payload.values()
+                for cat in (attr.get("colors") or {}).keys()
+            }
+        )
+
+        colors_df = None
+        if cat_labels:
+            cat_idx = pd.Index(cat_labels, name="category")
+            color_data = {}
+            for attr_name, spec in axis_payload.items():
+                cmap = spec.get("colors") or {}
+                series = pd.Series(
+                    [cmap.get(cat, None) for cat in cat_labels],
+                    index=cat_idx,
+                    dtype=object,
+                )
+                color_data[str(attr_name)] = series
+            colors_df = pd.DataFrame(color_data, index=cat_idx)
+
+        return manual_df, colors_df
 
 
     def close(self):  # pragma: no cover - cleanup depends on JS


### PR DESCRIPTION
## Summary
- simplify the matrix visualization manual category syncing logic so we only rely on the obs_store payloads
- add small helpers on the widget side to parse JSON payloads and build manual category data frames so redundant code is removed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691be98b3c6c832a8f107fc7eaf6ee77)