### PR TITLE
Show manual categories in axis labels

### DIFF
--- a/js/deck-gl/matrix/label_layers.js
+++ b/js/deck-gl/matrix/label_layers.js
@@ -50,7 +50,7 @@ export const ini_row_label_layer = (viz_state) => {
     id: 'row-label-layer',
     data: viz_state.labels.row_label_data,
     getPosition: (d, index) => row_label_get_position(d, index, viz_state),
-    getText: (d) => d.name,
+    getText: (d) => d.display_name || d.name,
     getSize: viz_state.viz.font_size.rows,
     getColor: [0, 0, 0],
     getAngle: 0,
@@ -90,7 +90,7 @@ export const ini_col_label_layer = (viz_state) => {
     id: 'col-label-layer',
     data: viz_state.labels.col_label_data,
     getPosition: (d, index) => col_label_get_position(d, index, viz_state),
-    getText: (d) => d.name,
+    getText: (d) => d.display_name || d.name,
     getSize: viz_state.viz.font_size.cols,
     getColor: [0, 0, 0],
     getAngle: 45, // Optional: Text angle in degrees

--- a/js/deck-gl/matrix/matrix_tooltip.js
+++ b/js/deck-gl/matrix/matrix_tooltip.js
@@ -11,12 +11,12 @@ export const get_tooltip = (viz_state, params) => {
     // Check which layer the tooltip is currently over
     if (layer.id === 'row-label-layer') {
       return {
-        html: `Row Label: ${object.name}`,
+        html: `Row Label: ${object.display_name || object.name}`,
         style: { color: 'white' },
       };
     } else if (layer.id === 'col-label-layer') {
       return {
-        html: `Col Label: ${object.name}`,
+        html: `Col Label: ${object.display_name || object.name}`,
         style: { color: 'white' },
       };
     } else if (layer.id === 'row-layer') {
@@ -44,8 +44,10 @@ export const get_tooltip = (viz_state, params) => {
     } else if (layer.id === 'mat-layer') {
       // Display the default tooltip for other layers
 
-      const row_name = viz_state.labels.row_label_data[object.row].name;
-      const col_name = viz_state.labels.col_label_data[object.col].name;
+      const row_entry = viz_state.labels.row_label_data[object.row];
+      const col_entry = viz_state.labels.col_label_data[object.col];
+      const row_name = row_entry?.display_name || row_entry?.name;
+      const col_name = col_entry?.display_name || col_entry?.name;
 
       return {
         html: `Row: ${row_name} <br> Column: ${col_name} <br> Value: ${object.value.toFixed(2)}`,

--- a/js/matrix/attr_state.js
+++ b/js/matrix/attr_state.js
@@ -242,10 +242,12 @@ export const refresh_attribute_layers = (deck_mat, layers_mat, viz_state) => {
   });
 
   layers_mat.row_label_layer = layers_mat.row_label_layer.clone({
+    data: viz_state.labels.row_label_data,
     updateTriggers: { getPosition: viz_state.order.current.row },
   });
 
   layers_mat.col_label_layer = layers_mat.col_label_layer.clone({
+    data: viz_state.labels.col_label_data,
     updateTriggers: { getPosition: viz_state.order.current.col },
   });
 

--- a/js/matrix/label_data.js
+++ b/js/matrix/label_data.js
@@ -1,5 +1,43 @@
 const index_offset = 1;
 
+const normalizeAxis = (axis) => (axis === 'col' ? 'col' : 'row');
+
+const labelKeyForAxis = (axis) =>
+  normalizeAxis(axis) === 'col' ? 'col_label_data' : 'row_label_data';
+
+const formatDisplayName = (name, manualValue) => {
+  if (!name) return '';
+  return manualValue ? `${name} (${manualValue})` : name;
+};
+
+export const update_label_display_names = (viz_state, axis) => {
+  if (!viz_state || !viz_state.labels) return;
+
+  const normalizedAxis = normalizeAxis(axis);
+  const labels_key = labelKeyForAxis(normalizedAxis);
+  const labels = viz_state.labels[labels_key];
+  if (!Array.isArray(labels)) return;
+
+  const flags = viz_state.manual_cat?.flags || {};
+  const store = viz_state.obs_store?.manual_cat?.[normalizedAxis];
+  const can_show = !!(
+    store?.getValueFor &&
+    store?.attribute &&
+    flags[normalizedAxis]
+  );
+
+  const updated = labels.map((entry) => {
+    const manualValue =
+      can_show && entry?.name ? store.getValueFor(entry.name) : null;
+    return {
+      ...entry,
+      display_name: formatDisplayName(entry?.name, manualValue),
+    };
+  });
+
+  viz_state.labels[labels_key] = updated;
+};
+
 export const set_col_label_data = (network, viz_state) => {
   const col_label_data = [];
 
@@ -30,6 +68,8 @@ export const set_col_label_data = (network, viz_state) => {
   viz_state.mat.orders.col.rankvar = col_label_data.map(
     (d) => d.rankvar + index_offset
   );
+
+  update_label_display_names(viz_state, 'col');
 };
 
 export const set_row_label_data = (network, viz_state) => {
@@ -61,4 +101,6 @@ export const set_row_label_data = (network, viz_state) => {
   viz_state.mat.orders.row.rankvar = row_label_data.map(
     (d) => d.rankvar + index_offset
   );
+
+  update_label_display_names(viz_state, 'row');
 };

--- a/js/obs_store/manual_category_store.js
+++ b/js/obs_store/manual_category_store.js
@@ -46,6 +46,14 @@ export class ManualCategoryStore {
     this.emit();
   }
 
+  getValueFor(name) {
+    if (name === null || name === undefined) return null;
+
+    const key = String(name);
+    const stored = this.values.get(key);
+    return stored === undefined ? null : stored;
+  }
+
   clear() {
     if (!this.attribute && this.values.size === 0 && this.colors.size === 0) {
       return;

--- a/js/viz/matrix_viz.js
+++ b/js/viz/matrix_viz.js
@@ -57,7 +57,11 @@ import {
   refresh_attribute_layers,
 } from '../matrix/attr_state';
 import { calc_dendro_polygons, ini_dendro } from '../matrix/dendro';
-import { set_row_label_data, set_col_label_data } from '../matrix/label_data';
+import {
+  set_row_label_data,
+  set_col_label_data,
+  update_label_display_names,
+} from '../matrix/label_data';
 import { set_mat_data } from '../matrix/mat_data';
 import { set_mat_constants } from '../matrix/set_constants';
 import { initialize_attribute_editor } from '../ui/attribute_editor';
@@ -233,6 +237,7 @@ export const matrix_viz = async (
     const applied = apply_manual_definitions_to_axis(viz_state, axis);
     if (!applied) return;
 
+    update_label_display_names(viz_state, axis);
     refresh_attribute_layers(deck_mat, layers_mat, viz_state);
 
     if (sync) {


### PR DESCRIPTION
## Summary
- append manual category values to row/column labels via new display names without renaming the underlying ids
- refresh deck.gl label layers and tooltips so they render the new display text whenever manual categories change
- expose a helper on the manual category store for retrieving stored values by node name

## Testing
- npx eslint js/obs_store/manual_category_store.js js/matrix/label_data.js js/viz/matrix_viz.js js/deck-gl/matrix/label_layers.js js/deck-gl/matrix/matrix_tooltip.js js/matrix/attr_state.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691de69e5690832a92c3c915a620fbea)