### PR TITLE
Handle dataset-prefixed cell IDs with underscore separator

### DIFF
--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -273,16 +273,40 @@ export const landscape_ist = async (
   viz_state.dataset_options = ini_model?.get('base_url_options') || [];
 
   const datasetLabel = dataset_name ? String(dataset_name) : '';
+  const datasetPrefixSeparator = '_';
   const prefixAttr = ini_model?.get('cell_name_prefix_col');
   const baseIdAttr = '__cell_base_id__';
 
   const filteredMeta = (() => {
-    if (!prefixAttr || !Array.isArray(meta_cell_attr)) {
+    if (!Array.isArray(meta_cell_attr)) {
       return {
         metaCell: meta_cell,
         metaAttr: meta_cell_attr,
         idMap: [],
       };
+    }
+
+    if (!prefixAttr && datasetLabel) {
+      const metaCell = {};
+      const idMap = [];
+
+      Object.entries(meta_cell || {}).forEach(([key, values]) => {
+        const keyStr = String(key);
+        const sepIdx = keyStr.indexOf(datasetPrefixSeparator);
+
+        if (sepIdx <= 0) return;
+
+        const datasetValue = keyStr.slice(0, sepIdx);
+        if (datasetValue !== datasetLabel) return;
+
+        const baseId = keyStr.slice(sepIdx + 1);
+        metaCell[baseId] = values;
+        idMap.push({ sourceId: key, baseId });
+      });
+
+      if (idMap.length) {
+        return { metaCell, metaAttr: meta_cell_attr, idMap };
+      }
     }
 
     const prefixIdx = meta_cell_attr.indexOf(prefixAttr);


### PR DESCRIPTION
## Summary
- add dataset prefix parsing for meta cell data when prefixed cell IDs include dataset name separated by an underscore
- keep dataset-scoped id mapping working even when no explicit prefix column is provided

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f9e1fabdc832abb9f969c6e82a4af)