### PR TITLE
improve gradient function

### DIFF
--- a/src/celldega/nbhd/__init__.py
+++ b/src/celldega/nbhd/__init__.py
@@ -1,7 +1,7 @@
 """Module for performing neighborhood analysis."""
 
 from .alpha_shapes import alpha_shape, alpha_shape_cell_clusters, filter_alpha_shapes
-from .gradient import calc_grad_nbhd_from_roi
+from .gradient import gradient_from_gdf
 from .hextile import generate_hextile, hextile_niche
 from .neighborhoods import (
     NBHD,
@@ -29,7 +29,6 @@ __all__ = [
     "_get_gdf_trx",
     "alpha_shape",
     "alpha_shape_cell_clusters",
-    "calc_grad_nbhd_from_roi",
     "calc_nbhd_bordering",
     "calc_nbhd_by_gene",
     "calc_nbhd_by_pop",
@@ -37,5 +36,6 @@ __all__ = [
     "filter_alpha_shapes",
     "generate_hextile",
     "get_nbhd_meta",
+    "gradient_from_gdf",
     "hextile_niche",
 ]

--- a/src/celldega/nbhd/__init__.py
+++ b/src/celldega/nbhd/__init__.py
@@ -17,6 +17,7 @@ from .utils import (
     _get_df_cell,
     _get_gdf_cell,
     _get_gdf_trx,
+    _get_micron_per_pixel,
 )
 
 
@@ -27,6 +28,7 @@ __all__ = [
     "_get_df_cell",
     "_get_gdf_cell",
     "_get_gdf_trx",
+    "_get_micron_per_pixel",
     "alpha_shape",
     "alpha_shape_cell_clusters",
     "calc_nbhd_bordering",

--- a/src/celldega/nbhd/gradient.py
+++ b/src/celldega/nbhd/gradient.py
@@ -1,9 +1,104 @@
 """Module for gradient polygon(s) generation."""
 
 import geopandas as gpd
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+from tqdm import tqdm
 
 
-def calc_grad_nbhd_from_roi(
+def gradient_from_gdf(
+    gdf,
+    scale_um_per_pixel=0.2125,  # This is for Xenium data
+    bin_width=10,
+    max_dist_um=50,
+    is_pixel_space=True,  # New flag: False if GDF is already in microns
+):
+    """
+    Generates concentric rings. Works with GDFs in pixel or micron units.
+    """
+    # 1. Determine effective scale
+    # If already in microns, 1 unit = 1 um. If in pixels, use the provided scale.
+    effective_scale = scale_um_per_pixel if is_pixel_space else 1.0
+
+    # Get the merged geometry
+    geometry = gdf.geometry.unary_union
+
+    # 2. Define distances in microns for labels
+    rings_um = list(range(0, max_dist_um + 1, bin_width))
+
+    # Define distances in GDF units (px or um) for geometric buffering
+    # d_gdf = d_um / scale_um_per_unit
+    rings_gdf_units = [r / effective_scale for r in rings_um]
+
+    # --- Label & Order Generation ---
+    outward_labels = [
+        f"out (+{rings_um[i]}~+{rings_um[i + 1]}) µm" for i in range(len(rings_um) - 1)
+    ]
+    inward_labels = [
+        f"in ({0 if rings_um[i] == 0 else -rings_um[i]}~-{rings_um[i + 1]}) µm"
+        for i in range(len(rings_um) - 1)
+    ]
+    bin_order = inward_labels[::-1] + outward_labels
+
+    def get_colors(cmap_name, n):
+        cmap = plt.get_cmap(cmap_name)
+        return [mcolors.to_hex(cmap(i)) for i in np.linspace(0.8, 0.3, n)]
+
+    dynamic_color_map = {
+        **dict(zip(outward_labels, get_colors("Blues", len(outward_labels)), strict=True)),
+        **dict(zip(inward_labels, get_colors("Reds", len(inward_labels)), strict=True)),
+    }
+
+    # --- Geometric Processing ---
+    global_ring_geoms = []
+    global_ring_labels = []
+
+    for direction in ["outward", "inward"]:
+        desc = f"Generating {direction} rings"
+        for i in tqdm(range(len(rings_gdf_units) - 1), desc=desc):
+            if direction == "outward":
+                d1, d2 = rings_gdf_units[i], rings_gdf_units[i + 1]
+                label = outward_labels[i]
+            else:
+                d1, d2 = -rings_gdf_units[i], -rings_gdf_units[i + 1]
+                label = inward_labels[i]
+
+            # Buffer based on native GDF units
+            geom_1 = geometry.buffer(d1)
+            geom_2 = geometry.buffer(d2)
+
+            if geom_1.is_empty and geom_2.is_empty:
+                continue
+
+            ring = (
+                geom_2.difference(geom_1) if direction == "outward" else geom_1.difference(geom_2)
+            )
+
+            if not ring.is_empty:
+                global_ring_geoms.append(ring)
+                global_ring_labels.append({"mode": direction, "ring_range_um": label})
+
+    # --- Build GeoDataFrame ---
+    gdf_rings = gpd.GeoDataFrame(global_ring_labels, geometry=global_ring_geoms, crs=gdf.crs)
+    gdf_rings["color"] = gdf_rings["ring_range_um"].map(dynamic_color_map).fillna("#cccccc")
+
+    # Calculate Area
+    area_native = gdf_rings.geometry.area
+    if is_pixel_space:
+        gdf_rings["area_px2"] = area_native
+        gdf_rings["area_um2"] = area_native * (scale_um_per_pixel**2)
+    else:
+        gdf_rings["area_um2"] = area_native
+        gdf_rings["area_px2"] = area_native / (scale_um_per_pixel**2)
+
+    gdf_rings["area"] = gdf_rings["area_um2"]
+    gdf_rings["name"] = gdf_rings["ring_range_um"]
+
+    return gdf_rings, bin_order
+
+
+def _calc_grad_nbhd_from_roi(
     polygon: gpd.GeoDataFrame,
     gdf_reference: gpd.GeoDataFrame,
     band_width: float = 300,

--- a/src/celldega/nbhd/utils.py
+++ b/src/celldega/nbhd/utils.py
@@ -120,6 +120,31 @@ def _get_gdf_trx(data_dir: str) -> gpd.GeoDataFrame:
     return gpd.GeoDataFrame(df_trx[["feature_name", "cell_id"]], geometry=geometry)
 
 
+def _get_micron_per_pixel(technology: str) -> float:
+    """
+    Retrieve the micron-per-pixel conversion factor for a given technology.
+
+    Parameters
+    ----------
+    technology : str
+        The spatial transcriptomics technology (e.g., 'Xenium', 'Merscope').
+
+    Returns
+    -------
+    float
+        The conversion factor in microns per pixel.
+
+    """
+    tech_lower = technology.lower()
+
+    if tech_lower == "xenium":
+        return 0.2125
+    if tech_lower == "merscope":
+        return 0.108
+    supported = ["Xenium", "Merscope"]
+    raise ValueError(f"'{technology}' is not supported. Please select from: {', '.join(supported)}")
+
+
 def _round_coordinates(
     geometry: base.BaseGeometry | None, precision: int = 2
 ) -> base.BaseGeometry | None:


### PR DESCRIPTION
The previous function `calc_grad_nbhd_from_roi()` has these limitations and therefore is depreciated as `_calc_grad_nbhd_from_roi()`. Once this PR is reviewed and approved, we can probably remove it:
1. Only work with gdf in micron space
2. Only go inside and not outside
3. Missing `name`,`color`,`area` that are handy to use Landscape to visualize rings
4. Missing flexibility to set max distance

A new function is created: `gradient_from_gdf()`. Improvemnts:1
1. Work with gdf in micron space like manual drawing as well as gdf in pixel space like the alpha shape created using Celldega
2. Easy to set bin width and max distance, and goes both inward and outward
3. Populate `name`,`color`,`area` so the gradient nbhd can be visualized in Landscape properly

Example:

"""
scale_um_per_pixel=dega.nbhd._get_micron_per_pixel(technology)
bin_width=10
max_dist_um=50

gdf_rings_merged, name_order = dega.nbhd.gradient_from_gdf(
    gdf_alpha_tumor,
    scale_um_per_pixel,
    bin_width,
    max_dist_um,
    is_pixel_space=True,
)
"""