### PR TITLE
Use compact transcript buffers and optimize scatter/aggregation paths

### DIFF
--- a/js/deck-gl/core/calc_viewport.js
+++ b/js/deck-gl/core/calc_viewport.js
@@ -85,41 +85,42 @@ export const calc_viewport = async (
     );
 
     // gene bar graph update
-    const filtered_transcripts = viz_state.combo_data.trx.filter((pos) => {
+    const trxCompact = viz_state.combo_data.trx_compact || {
+      names: [],
+      x: new Float32Array(),
+      y: new Float32Array(),
+    };
+    const geneCounts = new Map();
+    for (let i = 0; i < trxCompact.names.length; i++) {
+      const x = trxCompact.x[i];
+      const y = trxCompact.y[i];
+      let inView;
       if (!viz_state.rotation?.hasRotation) {
-        return (
-          pos.x >= viz_state.bounds.min_x &&
-          pos.x <= viz_state.bounds.max_x &&
-          pos.y >= viz_state.bounds.min_y &&
-          pos.y <= viz_state.bounds.max_y
-        );
+        inView =
+          x >= viz_state.bounds.min_x &&
+          x <= viz_state.bounds.max_x &&
+          y >= viz_state.bounds.min_y &&
+          y <= viz_state.bounds.max_y;
+      } else {
+        const [rotX, rotY] = rotate_point(x, y, viz_state.rotation);
+        inView =
+          rotX >= viz_state.bounds.min_x &&
+          rotX <= viz_state.bounds.max_x &&
+          rotY >= viz_state.bounds.min_y &&
+          rotY <= viz_state.bounds.max_y;
+      }
+      if (!inView) {
+        continue;
       }
 
-      const [rotX, rotY] = rotate_point(pos.x, pos.y, viz_state.rotation);
+      const name = trxCompact.names[i];
+      geneCounts.set(name, (geneCounts.get(name) || 0) + 1);
+    }
 
-      return (
-        rotX >= viz_state.bounds.min_x &&
-        rotX <= viz_state.bounds.max_x &&
-        rotY >= viz_state.bounds.min_y &&
-        rotY <= viz_state.bounds.max_y
-      );
-    });
-
-    const filtered_gene_names = filtered_transcripts.map(
-      (transcript) => transcript.name
-    );
-
-    const new_bar_data = filtered_gene_names
-      .reduce((acc, gene) => {
-        const existingGene = acc.find((item) => item.name === gene);
-        if (existingGene) {
-          existingGene.value += 1;
-        } else {
-          acc.push({ name: gene, value: 1 });
-        }
-        return acc;
-      }, [])
-      .filter((item) => item.value > 0)
+    const new_bar_data = Array.from(geneCounts, ([name, value]) => ({
+      name,
+      value,
+    }))
       .sort((a, b) => b.value - a.value)
       .slice(0, 100);
 
@@ -146,20 +147,15 @@ export const calc_viewport = async (
       );
     });
 
-    const filtered_cell_names = filtered_cells.map((cell) => cell.cat);
+    const cellCounts = new Map();
+    for (const cell of filtered_cells) {
+      cellCounts.set(cell.cat, (cellCounts.get(cell.cat) || 0) + 1);
+    }
 
-    const new_bar_data_cell = filtered_cell_names
-      .reduce((acc, cat) => {
-        const existing_cat = acc.find((item) => item.name === cat);
-        if (existing_cat) {
-          existing_cat.value += 1;
-        } else {
-          acc.push({ name: cat, value: 1 });
-        }
-        return acc;
-      }, [])
-      .filter((item) => item.value > 0)
-      .sort((a, b) => b.value - a.value);
+    const new_bar_data_cell = Array.from(cellCounts, ([name, value]) => ({
+      name,
+      value,
+    })).sort((a, b) => b.value - a.value);
 
     viz_state.obs_store.new_cell_bar_data.set(new_bar_data_cell);
   } else {

--- a/js/read_parquet/get_scatter_data.js
+++ b/js/read_parquet/get_scatter_data.js
@@ -12,16 +12,17 @@ export const get_scatter_data = (arrow_table) => {
   }
 
   try {
-    const flatCoordinateArray = arrow_table
-      .getChild('geometry')
-      .getChildAt(0)
-      .data.map((x) => x.values)
-      .reduce((acc, val) => {
-        const combined = new Float64Array(acc.length + val.length);
-        combined.set(acc);
-        combined.set(val, acc.length);
-        return combined;
-      }, new Float64Array(0));
+    const geometryColumn = arrow_table.getChild('geometry')?.getChildAt(0);
+    const chunks = geometryColumn?.data?.map((x) => x.values) || [];
+
+    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+    const flatCoordinateArray = new Float64Array(totalLength);
+
+    let offset = 0;
+    for (const chunk of chunks) {
+      flatCoordinateArray.set(chunk, offset);
+      offset += chunk.length;
+    }
 
     const size = flatCoordinateArray.length / arrow_table.numRows;
 

--- a/js/ui/switch_dataset.js
+++ b/js/ui/switch_dataset.js
@@ -410,6 +410,11 @@ export const switch_dataset = async (
     viz_state.genes.trx_names_array = [];
     viz_state.cats.polygon_cell_names = [];
     viz_state.combo_data.trx = [];
+    viz_state.combo_data.trx_compact = {
+      names: [],
+      x: new Float32Array(),
+      y: new Float32Array(),
+    };
 
     layers_obj.trx_layer = layers_obj.trx_layer.clone({
       id: `trx-layer-dataset-${new_index}`,

--- a/js/vector_tile/transcripts/grab_trx_tiles_in_view.js
+++ b/js/vector_tile/transcripts/grab_trx_tiles_in_view.js
@@ -59,6 +59,11 @@ export const grab_trx_tiles_in_view = async (
   if (!trx_arrow_table) {
     viz_state.genes.trx_names_array = [];
     viz_state.combo_data.trx = [];
+    viz_state.combo_data.trx_compact = {
+      names: [],
+      x: new Float32Array(),
+      y: new Float32Array(),
+    };
     return {
       length: 0,
       attributes: {
@@ -85,15 +90,24 @@ export const grab_trx_tiles_in_view = async (
 
   const trx_scatter_data = get_scatter_data(trx_arrow_table);
 
-  // Combine names and positions into a single array of objects
+  // Keep compact transcript buffers for viewport filtering/aggregation.
+  // This avoids allocating one JS object per transcript in hot update paths.
   const flatCoordinateArray = trx_scatter_data.attributes.getPosition.value;
-  viz_state.combo_data.trx = viz_state.genes.trx_names_array.map(
-    (name, index) => ({
-      name,
-      x: flatCoordinateArray[index * 2],
-      y: flatCoordinateArray[index * 2 + 1],
-    })
-  );
+  const trxCount = viz_state.genes.trx_names_array.length;
+  const xPositions = new Float32Array(trxCount);
+  const yPositions = new Float32Array(trxCount);
+  for (let i = 0; i < trxCount; i++) {
+    xPositions[i] = flatCoordinateArray[i * 2];
+    yPositions[i] = flatCoordinateArray[i * 2 + 1];
+  }
+
+  viz_state.combo_data.trx_compact = {
+    names: viz_state.genes.trx_names_array,
+    x: xPositions,
+    y: yPositions,
+  };
+  // Backward-compatible field retained for any external consumers.
+  viz_state.combo_data.trx = [];
 
   return trx_scatter_data;
 };

--- a/js/viz/landscape_ist.js
+++ b/js/viz/landscape_ist.js
@@ -515,6 +515,12 @@ export const landscape_ist = async (
   viz_state.cache.trx = await ini_cache();
 
   viz_state.combo_data = {};
+  viz_state.combo_data.trx = [];
+  viz_state.combo_data.trx_compact = {
+    names: [],
+    x: new Float32Array(),
+    y: new Float32Array(),
+  };
 
   viz_state.tooltip_cat_cell = '';
 

--- a/js/viz/yearbook.js
+++ b/js/viz/yearbook.js
@@ -412,6 +412,11 @@ export const yearbook = async (
 
   viz_state.combo_data = {};
   viz_state.combo_data.trx = [];
+  viz_state.combo_data.trx_compact = {
+    names: [],
+    x: new Float32Array(),
+    y: new Float32Array(),
+  };
   viz_state.combo_data.cell = [];
   viz_state.tooltip_cat_cell = '';
 
@@ -548,33 +553,36 @@ export const yearbook = async (
     // Use half the portrait data size as the radius for filtering
     const half_view_size = portrait_data_size / 2;
 
-    // Filter transcripts visible in any portrait
-    const filtered_transcripts = (viz_state.combo_data.trx || []).filter(
-      (pos) => {
-        return centers.some((center) => {
-          return (
-            pos.x >= center.x - half_view_size &&
-            pos.x <= center.x + half_view_size &&
-            pos.y >= center.y - half_view_size &&
-            pos.y <= center.y + half_view_size
-          );
-        });
+    // Filter transcripts visible in any portrait using compact buffers
+    const trxCompact = viz_state.combo_data.trx_compact || {
+      names: [],
+      x: new Float32Array(),
+      y: new Float32Array(),
+    };
+    const geneCounts = new Map();
+    for (let i = 0; i < trxCompact.names.length; i++) {
+      const x = trxCompact.x[i];
+      const y = trxCompact.y[i];
+      const inPortrait = centers.some((center) => {
+        return (
+          x >= center.x - half_view_size &&
+          x <= center.x + half_view_size &&
+          y >= center.y - half_view_size &&
+          y <= center.y + half_view_size
+        );
+      });
+      if (!inPortrait) {
+        continue;
       }
-    );
 
-    const filtered_gene_names = filtered_transcripts.map((t) => t.name);
+      const name = trxCompact.names[i];
+      geneCounts.set(name, (geneCounts.get(name) || 0) + 1);
+    }
 
-    const new_bar_data = filtered_gene_names
-      .reduce((acc, gene) => {
-        const existingGene = acc.find((item) => item.name === gene);
-        if (existingGene) {
-          existingGene.value += 1;
-        } else {
-          acc.push({ name: gene, value: 1 });
-        }
-        return acc;
-      }, [])
-      .filter((item) => item.value > 0)
+    const new_bar_data = Array.from(geneCounts, ([name, value]) => ({
+      name,
+      value,
+    }))
       .sort((a, b) => b.value - a.value)
       .slice(0, 100);
 
@@ -592,20 +600,15 @@ export const yearbook = async (
       });
     });
 
-    const filtered_cell_cats = filtered_cells.map((cell) => cell.cat);
+    const cellCounts = new Map();
+    for (const cell of filtered_cells) {
+      cellCounts.set(cell.cat, (cellCounts.get(cell.cat) || 0) + 1);
+    }
 
-    const new_bar_data_cell = filtered_cell_cats
-      .reduce((acc, cat) => {
-        const existing_cat = acc.find((item) => item.name === cat);
-        if (existing_cat) {
-          existing_cat.value += 1;
-        } else {
-          acc.push({ name: cat, value: 1 });
-        }
-        return acc;
-      }, [])
-      .filter((item) => item.value > 0)
-      .sort((a, b) => b.value - a.value);
+    const new_bar_data_cell = Array.from(cellCounts, ([name, value]) => ({
+      name,
+      value,
+    })).sort((a, b) => b.value - a.value);
 
     viz_state.obs_store.new_cell_bar_data.set(new_bar_data_cell);
   };


### PR DESCRIPTION
### Motivation
- Reduce memory churn and GC overhead by avoiding one-JS-object-per-transcript allocations in hot update paths and portrait/viewport filtering. 
- Improve performance of flattening chunked Arrow geometry data and make the scatter extraction robust to missing/empty children. 
- Simplify and speed up gene/cell bar aggregation logic during viewport and yearbook updates.

### Description
- Introduced a compact transcript buffer `trx_compact` (`names`, `x`, `y`) and populate it in `grab_trx_tiles_in_view`, while keeping `combo_data.trx` as a backward-compatible empty field. 
- Reworked `get_scatter_data` to concatenate geometry chunks into a single `Float64Array` via precomputed `totalLength` and single-copy fills instead of repeated `reduce`/allocations. 
- Updated `calc_viewport`, `landscape_ist`, and `yearbook` to use `trx_compact` for viewport/portrait membership tests and to aggregate gene counts via `Map` and `Array.from` sorted slices (and similarly replaced cell `reduce` logic with `Map`-based counting). 
- Initialize `viz_state.combo_data.trx_compact` in dataset switching and view initializers and handle empty/no-table cases by setting empty compact buffers.

### Testing
- Project build succeeded via `npm run build` without errors. 
- Automated test suite `npm test` completed and all tests passed. 
- Linting via `npm run lint` passed with no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9279c0dbc832ab38bff2d92a99f61)